### PR TITLE
Remove duplicate info on method parameters

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,45 +211,6 @@
               If the <code>constraints</code> argument is omitted, a default value containing a
               single <code>video</code> attribute set to <code>true</code> is assumed.
             </p>
-            <table class="parameters">
-              <tbody>
-                <tr>
-                  <th>
-                    Parameter
-                  </th>
-                  <th>
-                    Type
-                  </th>
-                  <th>
-                    Nullable
-                  </th>
-                  <th>
-                    Optional
-                  </th>
-                  <th>
-                    Description
-                  </th>
-                </tr>
-                <tr>
-                  <td class="prmName">
-                    constraints
-                  </td>
-                  <td class="prmType">
-                    <code>MediaStreamConstraints</code>
-                  </td>
-                  <td class="prmNullFalse">
-                    <span role="img" aria-label="False">✘</span>
-                  </td>
-                  <td class="prmOptFalse">
-                    <span role="img" aria-label="True">✓</span>
-                  </td>
-                  <td class="prmDesc"></td>
-                </tr>
-              </tbody>
-            </table>
-            <div>
-              <em>Return type:</em> <code>Promise&lt;MediaStream&gt;</code>
-            </div>
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
These were inherited from the previous respec WebIDL format, but they now represent a maintenance footgun
See also https://github.com/w3c/webrtc-pc/pull/1450