### PR TITLE
Clarify that restrictOwnAudio applies to document

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,10 +584,10 @@
                 disabled.</p>
                 <p>When <dfn>own audio restriction</dfn> is applied, the user
                 agent MUST attempt to remove any audio from the audio being
-                captured that was produced by the application that performed
+                captured that was produced by the document that performed
                 <code>getDisplayMedia</code>. If the user agent is not able to
                 remove the audio through processing it SHOULD remove the audio
-                by excluding the application's audio from being captured. If
+                by excluding the document's audio from being captured. If
                 this results in no audio being captured, the user agent MUST
                 keep the track muted until it is able to capture audio
                 again.</p>


### PR DESCRIPTION
Fixes #102 as decided in the April 11 Virtual Interim.