### PR TITLE
Clarify getUserMedia constraints do not apply unless listed

### DIFF
--- a/index.html
+++ b/index.html
@@ -447,8 +447,11 @@
         <p>Constraints serve a different purpose in
         <code><a>getDisplayMedia</a></code> than they do in
         <code><a href="https://w3c.github.io/mediacapture-main/#local-content">getUserMedia</a></code>.
-        They do not aid discovery, instead they are applied only after user-selection.
-        </p>
+        They do not aid discovery, instead they are applied only after user-selection.</p>
+        <p>This section define which constraints apply to <code><a>getDisplayMedia</a></code> tracks;
+        constraints defined for
+        <code><a href="https://w3c.github.io/mediacapture-main/#local-content">getUserMedia</a></code>
+        do not apply unless listed here.</p>
         <p>Some of these constraints enable user agent processing like downscaling
         and frame decimation, as well as display-specific features. Others enable
         observation of inherent properties of a user-selected


### PR DESCRIPTION
Fixes #103 according to decision made at the April 11 Virtual Interim.