### PR TITLE
A browser display surface is the rendered form of a browsing context.

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,7 +120,8 @@
         available to that application and therefore presented as a single
         <code><a>MediaStreamTrack</a></code>.
         </li>
-        <li>A <dfn>browser</dfn> <a>display surface</a> is the rendered form of a single document.
+        <li>A <dfn>browser</dfn> <a>display surface</a> is the rendered form of a
+        <a data-cite="!HTML/#browsing-context">browsing context</a>.
         This is not strictly limited to HTML [[HTML5]] documents, though the discussion in this
         document will address some specific concerns with the capture of HTML.
         </li>


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-screen-share/issues/60 (going through summary, saw assignment too late).