### PR TITLE
Add getCurrentBrowsingContextMedia

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,6 +162,8 @@
         <pre class="idl"
 >partial interface MediaDevices {
   Promise&lt;MediaStream&gt; getDisplayMedia(optional DisplayMediaStreamConstraints constraints = {});
+
+  Promise&lt;MediaStream&gt; getCurrentBrowsingContextMedia(optional DisplayMediaStreamConstraints constraints = {});
 };</pre>
         <dl data-link-for="MediaDevices" data-dfn-for="MediaDevices" class="methods">
           <dt>
@@ -370,6 +372,15 @@
                 <p>Return <var>p</var>.</p>
               </li>
             </ol>
+          </dd>
+          <dt>
+            <dfn>getCurrentBrowsingContextMedia</dfn>
+          </dt>
+          <dd>
+            <p>
+              Equivalent to {{MediaDevices/getDisplayMedia}}, other than that it
+              will trigger capturing the browser tab from which it was called.
+            </p>
           </dd>
         </dl>
       </section>


### PR DESCRIPTION
getCurrentBrowsingContextMedia is equivalent to getDisplayMedia, other than that it may only capture the tab from which it is called. This allows for a simpler selection to be displayed for the user - rather than an elaborate picker, a simple dialog box is used. This simplifies things for the user and reduces the risk of the user sharing something other than what they had intended.

See also:
1. [Explainer](https://docs.google.com/document/d/1CIQH2ygvw7eTGO__Pcds_D46Gcn-iPAqESQqOsHHfkI/edit?usp=sharing)
2. [Public discussion](https://lists.w3.org/Archives/Public/public-webrtc/2020Oct/0006.html)

We think that the security properties of own-tab capture are no worse than the version that goes via the picker. We note that the application will have control over the surface that is being displayed, and that can cause some sharing of information that would otherwise be inaccessible, such as colors on visited links, or content of embedded frames, but we think that the risks are no bigger than for regular sharing, and that the proposed, simple, prompt is good enough to mitigate this concern.

This new API will be subject to access-permissions laid down by the display-capture feature-policy. (Support will be added in Chrome for this feature-policy as part of the work on this feature.)