### PR TITLE
Throw on getDisplayMedia in non-fully active documents.

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,13 @@
             steps:</p>
             <ol>
               <li>
+                <p>If the [=relevant settings object=]'s
+                [=environment settings object/responsible document=] is NOT
+                [=Document/fully active=], return a promise <a>rejected</a>
+                with a {{DOMException}} object whose {{DOMException/name}}
+                attribute has the value {{"InvalidStateError"}}.</p>
+              </li>
+              <li>
                 <p>If the [=relevant global object=] of [=this=] does not have
           [=transient activation=], return a promise <a>rejected</a>
                 with a {{DOMException}} object whose {{DOMException/name}}


### PR DESCRIPTION
Follows https://github.com/w3c/mediacapture-main/pull/491.

This used to be implied in the old user-gesture model, but got lost when we switched to [transient activation](https://html.spec.whatwg.org/multipage/interaction.html#transient-activation) in https://github.com/w3c/mediacapture-screen-share/pull/132 which seems entirely timer-based.