### PR TITLE
Define the suppressLocalAudioPlayback constraint

### DIFF
--- a/index.html
+++ b/index.html
@@ -570,6 +570,33 @@
                 again.</p>
               </td>
             </tr>
+            <tr id="def-constraint-suppressLocalAudioPlayback">
+              <td><dfn>suppressLocalAudioPlayback</dfn></td>
+              <td>{{ConstrainBoolean}}</td>
+              <td>
+                <p>As a setting, this value indicates whether or not the user
+                agent is applying <a>local audio playback suppression</a> to
+                the source.</p>
+                <p>As a constraint, this value is only meaningful if the user
+                selects capturing a [=browser=] [=display surface=]. In that
+                case, a value of <code>true</code> indicates that the user
+                agent SHOULD perform <a>local audio playback suppression</a>
+                on the captured [=browser=] [=display surface=].</p>
+                <p>When <dfn>local audio playback suppression</dfn> is applied,
+                the user agent SHOULD stop relaying audio to the local speakers,
+                but that audio MUST still be captured by any ongoing audio-capturing
+                capture-sessions. This suppression MUST NOT be observable to the
+                captured document. Furthermore, the capturing document may only
+                observe whether it is applying <a>suppressLocalAudioPlayback</a>;
+                not whether that suppression is having an effect (i.e. can't
+                observe if the user is overriding this in the user agent).</p>
+                <p>When a [=browser=] [=display surface=] is subject to multiple
+                concurrent captures, <a>local audio playback suppression</a>
+                SHOULD be applied as long as at least one active audio-capturing
+                capture-session is constraining <a>suppressLocalAudioPlayback</a>
+                to <code>true</code>.</p>
+              </td>
+            </tr>
           </tbody>
         </table>  
         <p>When inherent properties of the underlying source of a user-selected
@@ -702,6 +729,7 @@ dictionary DisplayMediaStreamConstraints {
   boolean logicalSurface = true;
   boolean cursor = true;
   boolean restrictOwnAudio = true;
+  boolean suppressLocalAudioPlayback = true;
 };</pre>
           <dl  data-dfn-for="MediaTrackSupportedConstraints"
           class="dictionary-members">
@@ -738,6 +766,14 @@ dictionary DisplayMediaStreamConstraints {
                 recognized.
               </p>
             </dd>
+            <dt>
+              <dfn>suppressLocalAudioPlayback</dfn> of type {{boolean}}, defaulting to <code>true</code>
+            </dt>
+            <dd>
+              <p>
+                Whether {{suppressLocalAudioPlayback}} constraint is recognized.
+              </p>
+            </dd>
           </dl>
         </section>
         <section>
@@ -753,6 +789,7 @@ dictionary DisplayMediaStreamConstraints {
   ConstrainBoolean logicalSurface;
   ConstrainDOMString cursor;
   ConstrainBoolean restrictOwnAudio;
+  ConstrainBoolean suppressLocalAudioPlayback;
 };</pre>
           <dl data-dfn-for="MediaTrackConstraintSet" class=
           "dictionary-members">
@@ -791,6 +828,15 @@ dictionary DisplayMediaStreamConstraints {
               <p>
                 This constraint is only applicable to audio tracks. See
                 {{restrictOwnAudio}}.
+              </p>
+            </dd>
+            <dt>
+              <dfn>suppressLocalAudioPlayback</dfn> of type {{ConstrainBoolean}}
+            </dt>
+            <dd>
+              <p>
+                This constraint is only applicable to audio tracks. See
+                {{suppressLocalAudioPlayback}}.
               </p>
             </dd>
           </dl>


### PR DESCRIPTION
Fixes #161. Define suppressLocalAudioPlayback.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/164.html" title="Last updated on Jun 3, 2021, 11:26 AM UTC (624980f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/164/e2a35b3...eladalon1983:624980f.html" title="Last updated on Jun 3, 2021, 11:26 AM UTC (624980f)">Diff</a>