### PR TITLE
Remove restriction over changing capture source

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,8 @@
                     each media type in <var>requestedMediaTypes</var>.
                     The devices chosen MUST be the ones determined by the user.
                     Once selected, the source of a
-                    {{MediaStreamTrack}} MUST NOT change.</p>
+                    {{MediaStreamTrack}} MUST NOT change, unless the user
+                    permits it through their interaction with the user agent.</p>
                     <p>User Agents are encouraged to warn users against sharing
                     <a>browser</a> display devices as well as <a>monitor</a>
                     display devices where browser windows are visible, or


### PR DESCRIPTION
Addresses issue #81.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/170.html" title="Last updated on May 27, 2021, 2:59 PM UTC (dd6b808)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/170/556ec65...eladalon1983:dd6b808.html" title="Last updated on May 27, 2021, 2:59 PM UTC (dd6b808)">Diff</a>