### PR TITLE
Elaborate MediaTrackCapabilities extensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -528,7 +528,7 @@
                 This string (or each string, when a list) should be one of the
                 members of {{CursorCaptureConstraint}}. As a
                 setting, indicates if and when the cursor is included in the
-                captured [=display surface=].  As a capability, the user
+                captured [=display surface=]. As a capability, the user
                 agent MUST include only the set of values from
                 {{CursorCaptureConstraint}} it is capable of
                 supporting for this [=display surface=].
@@ -810,6 +810,7 @@ dictionary DisplayMediaStreamConstraints {
   DOMString displaySurface;
   boolean logicalSurface;
   DOMString cursor;
+  boolean restrictOwnAudio;
 };</pre>
           <dl data-link-for="MediaTrackSettings" data-dfn-for="MediaTrackSettings" class=
           "dictionary-members">
@@ -841,7 +842,62 @@ dictionary DisplayMediaStreamConstraints {
                 determines if and when the cursor is included in the captured display surface.
               </p>
             </dd>
+            <dt>
+               <dfn>restrictOwnAudio</dfn> of type {{boolean}}
+            </dt>
+            <dd>
+              <p>
+                Indicates whether the <a href="#dfn-restrictownaudio">restrictOwnAudio</a>
+                constraint is applied (<code>true</code>) or not (<code>false</code>).
+              </p>
+            </dd>
           </dl>
+        </section>
+        <section>
+          <h2>
+            Extensions to {{MediaTrackCapabilities}}
+          </h2>
+          <p>
+            When the {{MediaStreamTrack/getCapabilities()}} method is invoked on a video stream track,
+            the user agent must return the extended {{MediaTrackCapabilities}} dictionary,
+            representing the capabilities of the underlying user agent.
+          </p>
+          <pre class="idl"
+>partial dictionary MediaTrackCapabilities {
+  DOMString displaySurface;
+  boolean logicalSurface;
+  sequence&lt;DOMString&gt; cursor;
+};</pre>
+          <dl data-link-for="MediaTrackCapabilities" data-dfn-for="MediaTrackCapabilities" class=
+          "dictionary-members">
+            <dt>
+              <dfn>displaySurface</dfn> of type {{DOMString}}
+            </dt>
+            <dd>
+              <p>
+                MUST be the same value as is returned by {{MediaStreamTrack/getSettings()}},
+                rendering this property immutable from the application's viewpoint.
+              </p>
+            </dd>
+            <dt>
+              <dfn>logicalSurface</dfn> of type {{boolean}}
+            </dt>
+            <dd>
+              <p>
+                MUST be the same value as is returned by {{MediaStreamTrack/getSettings()}},
+                rendering this property immutable from the application's viewpoint.
+              </p>
+            </dd>
+            <dt>
+               <dfn>cursor</dfn> of type sequence&lt;DOMString&gt;
+            </dt>
+            <dd>
+              <p>
+                MUST consist of exactly the set of values from {{CursorCaptureConstraint}}
+                that the user agent is capable of supporting for this track.
+              </p>
+            </dd>
+        </dl>
         </section>
         <section>
           <h2>


### PR DESCRIPTION
Fixes issues w3c/mediacapture-screen-share#93 and w3c/mediacapture-screen-share#176.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/174.html" title="Last updated on Jun 3, 2021, 3:11 PM UTC (81705a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/174/556ec65...eladalon1983:81705a5.html" title="Last updated on Jun 3, 2021, 3:11 PM UTC (81705a5)">Diff</a>