### PR TITLE
Remove reference to obsolete event

### DIFF
--- a/index.html
+++ b/index.html
@@ -582,10 +582,7 @@
             <p>Update all affected constrainable properties at the same time.</p>
             <p>If this causes an "overconstrained" situation, then the user agent
             MUST ignore the culprit constraints for as long as they
-            overconstrain. The user agent MUST NOT mute the track, and
-            the user agent MUST NOT fire the
-            <a href="https://www.w3.org/TR/mediacapture-streams#event-mediastreamtrack-overconstrained">overconstrained</a>
-            event.</p>
+            overconstrain. The user agent MUST NOT mute the track.</p>
           </li>
         </ol>
         <div class="note">


### PR DESCRIPTION
Fixes #168.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/178.html" title="Last updated on Jun 3, 2021, 1:23 PM UTC (b8f5458)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/178/556ec65...eladalon1983:b8f5458.html" title="Last updated on Jun 3, 2021, 1:23 PM UTC (b8f5458)">Diff</a>