### PR TITLE
Use the displaySurface constraint to signal application preference

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
           <dd>
             <p>Prompts the user for permission to live-capture their display.</p>
             <p>
-              The user agent MUST let the end-user choose which [=display surface]= to share
+              The user agent MUST let the end-user choose which [=display surface=] to share
               out of all available choices every time, and MUST NOT use <var>constraints</var>
               to limit that choice.
             </p>

--- a/index.html
+++ b/index.html
@@ -171,10 +171,9 @@
               to limit that choice.
             </p>
             <p>
-              The user agent MAY allow the application to use the {{displaySurface}} constraint to
-              signal a preference for a specific [=display surface=] type. The user agent MUST still
-              offer the user unlimited choice of any [=display surface=], but MAY order the sources
-              offered to the user according to this constraint.
+              The user agent MAY use the presence of the {{displaySurface}} constraint and its value to
+              influence the presentation to the user of the sources to pick from. The user agent MUST still
+              offer the user unlimited choice of any [=display surface=].
               It is advised that allowing applications to nudge users towards sharing a monitor
               poses risks to user privacy. User agent may wish to ignore such hints.
             </p>

--- a/index.html
+++ b/index.html
@@ -175,7 +175,8 @@
               influence the presentation to the user of the sources to pick from. The user agent MUST still
               offer the user unlimited choice of any [=display surface=].
               The user agent is strongly recommended to steer users away from sharing a monitor,
-              as this poses risks to user privacy.
+              as this poses
+              <a href="#security-and-permissions">risks to user privacy</a>.
             </p>
             <p>  
               Other than the {{displaySurface}} constraint, <var>constraints</var> MUST be applied

--- a/index.html
+++ b/index.html
@@ -174,8 +174,8 @@
               The user agent MAY use the presence of the {{displaySurface}} constraint and its value to
               influence the presentation to the user of the sources to pick from. The user agent MUST still
               offer the user unlimited choice of any [=display surface=].
-              It is advised that allowing applications to nudge users towards sharing a monitor
-              poses risks to user privacy. User agent may wish to ignore such hints.
+              The user agent is strongly recommended to steer users away from sharing a monitor,
+              as this poses risks to user privacy.
             </p>
             <p>  
               Other than the {{displaySurface}} constraint, <var>constraints</var> MUST be applied

--- a/index.html
+++ b/index.html
@@ -166,13 +166,19 @@
           <dd>
             <p>Prompts the user for permission to live-capture their display.</p>
             <p>
-              The user agent MUST let the end-user choose which display surface to share
-              out of all available choices every time, and MUST NOT use
-              <var>constraints</var> to limit that choice. Instead,
-              <var>constraints</var> MUST be applied to the media chosen by the user,
-              only after they have made their selection. This prevents an application
-              from influencing the selection of sources, see <a href="#constraints"></a>
-              for details.
+              The user agent MUST let the end-user choose which [=display surface]= to share
+              out of all available choices every time, and MUST NOT use <var>constraints</var>
+              to limit that choice.
+            </p>
+            <p>
+              The user agent MAY allow the application to use the {{displaySurface}} constraint to
+              signal a preference for a specific [=display surface=] type. The user agent MUST still
+              offer the user unlimited choice of any [=display surface=], but MAY order the sources
+              offered to the user according to this constraint.
+            </p>
+            <p>  
+              Other than the {{displaySurface}} constraint, <var>constraints</var> MUST be applied
+              to the media chosen by the user only after the user has made their selection.
             </p>
             <p>
               In the case of audio, the user agent MAY present the end-user with audio sources
@@ -417,6 +423,9 @@
           whether audio, video or audio and video display sources are present. <img alt=
           "(This is a fingerprinting vector.)" src="images/fingerprint.png" width="15" height="21">
         </p>
+        <p>
+          Note that accepting the {{displaySurface}} constraint does not limit user selection.
+        </p>
       </section>
       <section>
         <h2 id="constrainable-properties">
@@ -505,12 +514,27 @@
               <td><dfn>displaySurface</dfn></td>
               <td>{{ConstrainDOMString}}</td>
               <td>
-                This string (or each string, when a list) should be one of the
-                members of {{DisplayCaptureSurfaceType}}. As a
-                setting, indicates the type of [=display surface=] that
-                is being captured. As a capability, the setting value MUST be
-                the lone value present, rendering this property immutable from
-                the application viewpoint.
+                <p>
+                  This string (or each string, when a list) should be one of the
+                  members of {{DisplayCaptureSurfaceType}}.
+                </p>
+                <p>
+                  As a setting, indicates the type of [=display surface=] that
+                  is being captured.
+                </p>
+                <p>
+                  As a capability, the setting value MUST be
+                  the lone value present, rendering this property immutable from
+                  the application viewpoint.
+                </p>
+                <p>
+                  As a constraint, the value signals the application's preference
+                  of a particular [=display surface=] type to the user agent;
+                  the user agent MAY reorder the options offered to the user
+                  according to that preference. This constraint is ignored for all
+                  other purposes, and can therefore not cause any side effects
+                  (such as being the cause of <code>OverconstrainedError</code>).
+                </p>
               </td>
             </tr>
             <tr id="def-constraint-logicalSurface">

--- a/index.html
+++ b/index.html
@@ -175,6 +175,8 @@
               signal a preference for a specific [=display surface=] type. The user agent MUST still
               offer the user unlimited choice of any [=display surface=], but MAY order the sources
               offered to the user according to this constraint.
+              It is advised that allowing applications to nudge users towards sharing a monitor
+              poses risks to user privacy. User agent may wish to ignore such hints.
             </p>
             <p>  
               Other than the {{displaySurface}} constraint, <var>constraints</var> MUST be applied


### PR DESCRIPTION
Allow the application to use the displaySurface constraint to signal its preference of display-surface. The user agent MAY use that signal in order to reorder the options offered to the user. The user agent MUST NOT use that constraint to limit the selection.

Fixes #184.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/186.html" title="Last updated on Sep 15, 2021, 7:35 PM UTC (db4f502)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/186/2c40d54...eladalon1983:db4f502.html" title="Last updated on Sep 15, 2021, 7:35 PM UTC (db4f502)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/186.html" title="Last updated on Mar 17, 2022, 4:38 PM UTC (9df74fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/186/2c40d54...eladalon1983:9df74fd.html" title="Last updated on Mar 17, 2022, 4:38 PM UTC (9df74fd)">Diff</a>