### PR TITLE
Integrate with Permissions spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1081,6 +1081,25 @@ dictionary DisplayMediaStreamConstraints {
         </div>
       </section>
     </section>
+    <section data-cite="permissions">
+      <h1 id="permissions-intergration">Permissions Integration</h1>
+      <p>
+        <cite>Screen Capture</cite> is a [=powerful feature=], requiring [=express permission=] to be used.
+      </p>
+      <p>
+        As required for integration with the [[[Permissions]]] specification, this specification defines the following:
+      </p>
+      <dl>
+        <dt>
+          [=powerful feature/permission state constraints=]
+        </dt>
+        <dd>
+          Valid values for this descriptor's <a>permission state</a> are
+          {{PermissionState/"prompt"}} and {{PermissionState/"denied"}}. The user agent MUST NOT
+          ever set this descriptor's <a>permission state</a> to {{PermissionState/"granted"}}.
+        </dd>
+      </dl>
+    </section>
     <section>
       <h1 id=feature-policy-integration>Permissions Policy Integration</h1>
       <p>This specification defines a [=policy-controlled feature=]


### PR DESCRIPTION
We are moving stuff out of the Permission spec and into their own spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/196.html" title="Last updated on Nov 4, 2021, 4:46 AM UTC (c4306b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/196/dd36026...c4306b8.html" title="Last updated on Nov 4, 2021, 4:46 AM UTC (c4306b8)">Diff</a>