### PR TITLE
Define "display-capture" without referencing PermissionName enum

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,8 +290,8 @@
                   </li>
                   <li>
                     <p>[=Prompt the user to choose=]
-                    a display device, with a {{PermissionDescriptor}} named
-                    {{PermissionName/"display-capture"}}, resulting in a set of
+                    a display device, for a {{PermissionDescriptor}} with its
+                    {{PermissionDescriptor/name}} set to "display-capture", resulting in a set of
                     provided media.</p>
                     <p>The provided media MUST include precisely one video track.</p>
                     <p>The provided media MUST include at most one audio track. This audio
@@ -600,7 +600,7 @@
               </td>
             </tr>
           </tbody>
-        </table>  
+        </table>
         <p>When inherent properties of the underlying source of a user-selected
         <a>display surface</a> change, for example in response to the end-user
         resizing a captured window, and these changes render the capabilities
@@ -783,7 +783,7 @@ dictionary DisplayMediaStreamConstraints {
           <p>
             {{MediaTrackConstraintSet}} is used for reading the current status of constraints.
           </p>
-          <pre class="idl" 
+          <pre class="idl"
 >partial dictionary MediaTrackConstraintSet {
   ConstrainDOMString displaySurface;
   ConstrainBoolean logicalSurface;
@@ -1084,7 +1084,8 @@ dictionary DisplayMediaStreamConstraints {
     <section data-cite="permissions">
       <h1 id="permissions-intergration">Permissions Integration</h1>
       <p>
-        <cite>Screen Capture</cite> is a [=powerful feature=], requiring [=express permission=] to be used.
+        <cite>Screen Capture</cite> is a [=powerful feature=] which is identified by the
+        [=powerful feature/name=] "display-capture", requiring [=express permission=] to be used.
       </p>
       <p>
         As required for integration with the [[[Permissions]]] specification, this specification defines the following:


### PR DESCRIPTION
Small follow-up to c46645bf5de1c2835bf7a150681d97ac09d19dab.

cc @marcoscaceres


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/mediacapture-screen-share/pull/197.html" title="Last updated on Nov 15, 2021, 6:35 PM UTC (3d691fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/197/3a9aff7...miketaylr:3d691fb.html" title="Last updated on Nov 15, 2021, 6:35 PM UTC (3d691fb)">Diff</a>