### PR TITLE
Move normative statements out of the (non-normative) Security & Permissions

### DIFF
--- a/index.html
+++ b/index.html
@@ -373,9 +373,8 @@
               partially transparent captured <a>display surface</a>.
             </p>
             <p>
-              In the case where the user prompt displays previews of the various surfaces available for selection,
-              the <a>user agent</a> MUST NOT capture, for the newly created {{MediaStreamTrack}}, the previews
-              that the user did not intend to share explicitly.
+              For the newly created {{MediaStreamTrack}}, the <a>user agent</a> MUST NOT capture the
+              prompt that was shown to the user.
             </p>
             <p>
               Information that is not currently rendered to the screen SHOULD be obscured in captures

--- a/index.html
+++ b/index.html
@@ -1292,7 +1292,7 @@ dictionary DisplayMediaStreamConstraints {
           Authorizing Display Capture
         </h2>
         <p>
-          This document provides recommends that implementations provide additional limitations on
+          This document encourages implementations to provide additional limitations on
           the mechanisms used to affirm user consent. These limitations are designed to mitigate
           the security and privacy risks that the API poses.
         </p>
@@ -1357,13 +1357,13 @@ dictionary DisplayMediaStreamConstraints {
             Capabilities Depending on Elevated Permissions
           </h2>
           <p>
-            <a>Elevated permissions</a> are recommended as a prerequisite for access to capture of
+            <a>Elevated permissions</a> are encouraged as a prerequisite for access to capture of
             <a>monitor</a> or <a>browser</a> <a>display surfaces</a>. Note that capture of a
             complete <a>monitor</a> is included because this could include a window from the
             <a>user agent</a>.
           </p>
           <p>
-            Similarly, <a>elevated permissions</a> are a recommended prerequisite for access to
+            Similarly, <a>elevated permissions</a> are an encouraged prerequisite for access to
             <a>logical display surfaces</a>, where that would not ordinarily be provided.
           </p>
           <p>
@@ -1379,7 +1379,7 @@ dictionary DisplayMediaStreamConstraints {
         </h2>
         <p>
           Implementations are advised to provide user feedback and control mechanisms similar to
-          those offered users when sharing a camera or microphone, as recommended in
+          those offered users when sharing a camera or microphone, as encouraged in
           [[GETUSERMEDIA]].
         </p>
         <p>

--- a/index.html
+++ b/index.html
@@ -379,7 +379,7 @@
             </p>
             <p>
               Information that is not currently rendered to the screen SHOULD be obscured in captures
-              unless the application has been specifically authorized to access that content (E.g.
+              unless the application has been specifically authorized to access that content (e.g.
               through means such as <a>elevated permissions</a>).
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -1238,7 +1238,7 @@ dictionary DisplayMediaStreamConstraints {
           human recipient is less able to process content that appears only briefly.
         </p>
         <p>
-          It is recommended that information that is not currently rendered to the screen be
+          It is encouraged that information that is not currently rendered to the screen be
           obscured in captures unless the application has been specifically authorized to access
           that content through <a>elevated permissions</a>.
         </p>
@@ -1281,7 +1281,7 @@ dictionary DisplayMediaStreamConstraints {
           <a>window</a> that is accompanied by the audio of the entire system, including applications
           unrelated to that window, will not be shared without <a>active
           user consent</a>. It is important that the user is aware of what content will be shared,
-          including any possible audio. It is strongly recommended that the user is allowed to give
+          including any possible audio. It is strongly encouraged that the user is allowed to give
           consent to video but not audio, resulting in a video-only stream. This ensures that the
           request for audio is always optional and does not restrict the user's choices compared to
           a video-only request.
@@ -1367,7 +1367,7 @@ dictionary DisplayMediaStreamConstraints {
             <a>logical display surfaces</a>, where that would not ordinarily be provided.
           </p>
           <p>
-            It is recommended that <a>elevated permissions</a> that are granted to an origin
+            It is encouraged that <a>elevated permissions</a> that are granted to an origin
             be persisted. An <a>elevated permissions</a> process in part relies on its novelty to
             ensure that it correctly captures user intent.
           </p>

--- a/index.html
+++ b/index.html
@@ -1260,7 +1260,7 @@ dictionary DisplayMediaStreamConstraints {
         </p>
         <p>
           When capturing a <a>window</a> or other <a>display surface</a> that is partially transparent,
-          any content behind it will not be captured.</a>.
+          any content behind it will not be captured</a>.
         </p>
         <p>
           There is a risk that the user prompt be exposed to the web page for a short amount of time

--- a/index.html
+++ b/index.html
@@ -1261,7 +1261,7 @@ dictionary DisplayMediaStreamConstraints {
         </p>
         <p>
           When capturing a <a>window</a> or other <a>display surface</a> that is partially transparent,
-          the content from the background will not be captured.</a>.
+          any content behind it will not be captured.</a>.
         </p>
         <p>
           There is a risk that the user prompt be exposed to the web page for a short amount of time

--- a/index.html
+++ b/index.html
@@ -383,7 +383,7 @@
             </p>
             <p>
               The <a>user agent</a> MUST NOT share audio without <a>active user consent</a>, for example
-              if the capture of the video of a <a>window</a> is accompanied by capture the audio of the
+              if the capture of the video of a <a>window</a> is accompanied by capture of the audio of the
               entire system, including applications unrelated to that window.
             </p>
           </dd>

--- a/index.html
+++ b/index.html
@@ -368,6 +368,25 @@
                 <p>Return <var>p</var>.</p>
               </li>
             </ol>
+            <p>
+              The <a>user agent</a> MUST NOT capture content from the background of a
+              partially transparent captured <a>display surface</a>.
+            </p>
+            <p>
+              In the case the user prompt displays previews of the various surfaces available for selection,
+              the <a>user agent</a> MUST NOT capture, for the newly created {{MediaStreamTrack}}, the previews
+              that the user did not intend to share explicitly.
+            </p>
+            <p>
+              Information that is not currently rendered to the screen SHOULD be obscured in captures
+              unless the application has been specifically authorized to access that content (E.g.
+              through means such as <a>elevated permissions</a>).
+            </p>
+            <p>
+              The <a>user agent</a> MUST NOT share audio without <a>active user consent</a>. For example,
+              if the capture of the video of a <a>window</a> is accompanied by capture the audio of the
+              entire system, including applications unrelated to that window.
+            </p>
           </dd>
         </dl>
       </section>
@@ -1181,10 +1200,6 @@ dictionary DisplayMediaStreamConstraints {
         This section is informative; however, it notes some serious risks to platform security if
         the advice it contains are not adhered to.
       </p>
-      <p class="issue">
-        This is consistent with other documents, but the absence of strong normative language here
-        is a little worrying.
-      </p>
       <p>
         The risks to user privacy and security posed by capture of displayed content are twofold.
         The immediate and obvious risk is that users inadvertently share content that they did not
@@ -1194,7 +1209,7 @@ dictionary DisplayMediaStreamConstraints {
         Display capture presents a less obvious risk to the cross site request forgery protections
         offered by the browser sandbox. Display and capture of information that is also under the
         control of an application, even indirectly, can allow that application to access
-        information that would otherwise by inaccessible to it directly. For example, the canvas
+        information that would otherwise be inaccessible to it directly. For example, the canvas
         API does not permit sampling of a canvas, or conversion to an accessible form if it is not
         origin-clean [[2DCONTEXT]].
       </p>
@@ -1223,9 +1238,9 @@ dictionary DisplayMediaStreamConstraints {
           human recipient is less able to process content that appears only briefly.
         </p>
         <p>
-          Information that is not currently rendered to the screen SHOULD be obscured in captures
-          unless the application has been specifically authorized to access that content (this
-          might require <a>elevated permissions</a>).
+          It is recommended that information that is not currently rendered to the screen be
+          obscured in captures unless the application has been specifically authorized to access
+          that content through <a>elevated permissions</a>.
         </p>
         <p>
           How obscured areas of the <a>logical display surface</a> are captured to produce a
@@ -1238,25 +1253,22 @@ dictionary DisplayMediaStreamConstraints {
           hatching.
         </p>
         <p>
-          Some systems MAY only capture the <a>logical display surface</a>. Devices with small
+          Some systems may only capture the <a>logical display surface</a>. Devices with small
           screens, for instance, do not typically have the concept of a <a>window</a>, and render
           applications in full screen modes only. These systems might provide a capture of an
           application that is not currently visible, which could be unusable without capturing the
           <a>logical display surface</a>.
         </p>
         <p>
-          An important consideration when capturing a <a>window</a> or other <a>display surface</a>
-          that is partially transparent is that content from the background might be shared. A
-          <a>user agent</a> MUST NOT capture content from the background of a captured <a>display
-          surface</a>.
+          When capturing a <a>window</a> or other <a>display surface</a> that is partially transparent,
+          the content from the background will not be captured.</a>.
         </p>
         <p>
           There is a risk that the user prompt be exposed to the web page for a short amount of time
           by the newly created {{MediaStreamTrack}}, for instance if the user
           selects the screen on which the user prompt is displayed.
-          In the case the user prompt displays previews of the various surfaces available for selection,
-          the <a>user agent</a> MUST NOT capture, for the newly created {{MediaStreamTrack}},
-          the previews that the user did not intend to share explicitly.
+          In the case of the user prompt displaying previews of the various surfaces available for selection,
+          those previews will not be captured by the newly created {{MediaStreamTrack}}.
         </p>
         <h2>
           Capturing Audio
@@ -1265,9 +1277,9 @@ dictionary DisplayMediaStreamConstraints {
           {{MediaDevices/getDisplayMedia}} allows capturing audio alongside video, this poses
           privacy and security concern as this may expose additional information about system
           applications, and the set of shared audio sources are not necessarily the same as the set
-          of shared video sources. For example, a <a>user agent</a> MAY be capturing the video of a
-          <a>window</a> and capture the audio of the entire system, including applications
-          unrelated to that window. The <a>user agent</a> MUST NOT share audio without <a>active
+          of shared video sources. For example, the capture of the video of a
+          <a>window</a> that is accompanied by the audio of the entire system, including applications
+          unrelated to that window, will not be shared without <a>active
           user consent</a>. It is important that the user is aware of what content will be shared,
           including any possible audio. It is strongly recommended that the user is allowed to give
           consent to video but not audio, resulting in a video-only stream. This ensures that the
@@ -1355,8 +1367,8 @@ dictionary DisplayMediaStreamConstraints {
             <a>logical display surfaces</a>, where that would not ordinarily be provided.
           </p>
           <p>
-            A <a>user agent</a> SHOULD persist any <a>elevated permissions</a> that are granted to
-            an origin. An <a>elevated permissions</a> process in part relies on its novelty to
+            It is recommended that <a>elevated permissions</a> that are granted to an origin
+            be persisted. An <a>elevated permissions</a> process in part relies on its novelty to
             ensure that it correctly captures user intent.
           </p>
         </section>

--- a/index.html
+++ b/index.html
@@ -369,7 +369,7 @@
               </li>
             </ol>
             <p>
-              The <a>user agent</a> MUST NOT capture content from the background of a
+              The <a>user agent</a> MUST NOT capture content that's behind a
               partially transparent captured <a>display surface</a>.
             </p>
             <p>

--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
               through means such as <a>elevated permissions</a>).
             </p>
             <p>
-              The <a>user agent</a> MUST NOT share audio without <a>active user consent</a>. For example,
+              The <a>user agent</a> MUST NOT share audio without <a>active user consent</a>, for example
               if the capture of the video of a <a>window</a> is accompanied by capture the audio of the
               entire system, including applications unrelated to that window.
             </p>

--- a/index.html
+++ b/index.html
@@ -373,7 +373,7 @@
               partially transparent captured <a>display surface</a>.
             </p>
             <p>
-              In the case the user prompt displays previews of the various surfaces available for selection,
+              In the case where the user prompt displays previews of the various surfaces available for selection,
               the <a>user agent</a> MUST NOT capture, for the newly created {{MediaStreamTrack}}, the previews
               that the user did not intend to share explicitly.
             </p>


### PR DESCRIPTION
Fixes #126.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-screen-share/pull/207.html" title="Last updated on Feb 3, 2022, 3:39 PM UTC (a1cc5cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/207/f725538...jan-ivar:a1cc5cb.html" title="Last updated on Feb 3, 2022, 3:39 PM UTC (a1cc5cb)">Diff</a>