### PR TITLE
Remove the "application" DisplayCaptureSurfaceType

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,11 +98,6 @@
         <li>A <dfn data-lt="windows">window</dfn> <a>display surface</a> is a single contiguous
         surface that is used by a single application.
         </li>
-        <li>A single application might have several <a>windows</a> available to it, and those can
-        be aggregated into a single <dfn>application</dfn> surface, representing all the windows
-        available to that application and therefore presented as a single
-        {{MediaStreamTrack}}.
-        </li>
         <li>A <dfn>browser</dfn> <a>display surface</a> is the rendered form of a
         [=browsing context=].
         This is not strictly limited to HTML [[HTML]] documents, though the discussion in this
@@ -186,10 +181,10 @@
               In the case of audio, the user agent MAY present the end-user with audio sources
               to share. Which choices are available to choose from is up to the user agent, and
               the audio source(s) are not necessarily the same as the video source(s). An audio
-              source may be a particular <a>application</a>, <a>window</a>, <a>browser</a>, the
-              entire system audio or any combination thereof. Unlike
-              {{MediaDevices/getUserMedia()}} with regards to audio+video, the user agent is
-              allowed not to return audio even if the audio constraint is present. If the user
+              source may be a particular <a>window</a>, <a>browser</a>, the entire system audio
+              or any combination thereof.
+              Unlike {{MediaDevices/getUserMedia()}} with regards to audio+video, the user agent
+              is allowed not to return audio even if the audio constraint is present. If the user
               agent knows no audio will be shared for the lifetime of the stream it MUST NOT
               include an audio track in the resulting stream. The user agent MAY accept a
               request for audio and video by only returning a video track in the resulting
@@ -405,8 +400,8 @@
           A <a>display surface</a> that is being shared may temporarily or permanently become
           inaccessible to the application because of actions taken by the operating system or user
           agent. What makes a <a>display surface</a> considered inaccesible is outside the scope
-          of this specification, but examples MAY include a <a>monitor</a> disconnecting, an
-          <a>application</a>, <a>window</a> or <a>browser</a> closing or becoming minimized,
+          of this specification, but examples MAY include a <a>monitor</a> disconnecting, a
+          <a>window</a> or <a>browser</a> closing or becoming minimized,
           or due to an incoming call on a phone.
         </p>
         <p class="note">
@@ -416,8 +411,8 @@
         <p>
           When <a>display surface</a> enters an inaccessible state that is not necessarily
           permanent, the user agent MUST queue a task that
-          [= set a track's muted state|sets the muted state =]
-          of the corresponding media track to <code>true</code>.
+          [= set a track's muted state|sets the muted state =] of the corresponding media
+          track to <code>true</code>.
         </p>
         <p>
           When <a>display surface</a> exits an inaccessible state and becomes accessible, the
@@ -427,9 +422,8 @@
         </p>
         <p>
           When a <a>display surface</a> enters an inaccessible state that is permanent (such as
-          the source application terminating), the user agent MUST queue a task that
-          [= track/ended | ends =] the
-          corresponding media track.
+          the source <a>window</a> closing), the user agent MUST queue a task that
+          [= track/ended | ends =] the corresponding media track.
         </p>
         <p>
           A stream that was just returned by {{MediaDevices/getDisplayMedia}} MAY contain
@@ -1006,7 +1000,6 @@ dictionary DisplayMediaStreamConstraints {
 >enum DisplayCaptureSurfaceType {
   "monitor",
   "window",
-  "application",
   "browser"
 };</pre>
           <table  data-dfn-for="DisplayCaptureSurfaceType"
@@ -1032,16 +1025,6 @@ dictionary DisplayMediaStreamConstraints {
                 </td>
                 <td>
                   a [= window =] [=display surface=], or single application window
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <dfn id=
-                  "idl-def-DisplayCaptureSurfaceType.application">application</dfn>
-                </td>
-                <td>
-                  an [= application=] [=display surface=], or entire collection of windows for
-                  an application
                 </td>
               </tr>
               <tr>

--- a/index.html
+++ b/index.html
@@ -411,8 +411,8 @@
         <p>
           When <a>display surface</a> enters an inaccessible state that is not necessarily
           permanent, the user agent MUST queue a task that
-          [= set a track's muted state|sets the muted state =] of the corresponding media
-          track to <code>true</code>.
+          [= set a track's muted state|sets the muted state =]
+          of the corresponding media track to <code>true</code>.
         </p>
         <p>
           When <a>display surface</a> exits an inaccessible state and becomes accessible, the


### PR DESCRIPTION
Fixes #189.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/215.html" title="Last updated on Mar 22, 2022, 10:51 AM UTC (ddb2d58)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/215/edc7772...eladalon1983:ddb2d58.html" title="Last updated on Mar 22, 2022, 10:51 AM UTC (ddb2d58)">Diff</a>