### PR TITLE
Clarify browser display-surface is top-level viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
         {{MediaStreamTrack}}.
         </li>
         <li>A <dfn>browser</dfn> <a>display surface</a> is the rendered form of a
-        [=browsing context=].
+        [=top-level browsing context=]'s <a data-cite="HTML#viewport">viewport</a>.
         This is not strictly limited to HTML [[HTML]] documents, though the discussion in this
         document will address some specific concerns with the capture of HTML.
         </li>


### PR DESCRIPTION
With more specs referencing this definition, it's useful to clarify this definition. cc @martinthomson @youennf PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/mediacapture-screen-share/pull/217.html" title="Last updated on Apr 1, 2022, 8:42 PM UTC (4f7c3a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/217/edc7772...jan-ivar:4f7c3a0.html" title="Last updated on Apr 1, 2022, 8:42 PM UTC (4f7c3a0)">Diff</a>