### PR TITLE
Markup definitions to make them reusable in other specs

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,20 +86,25 @@
       </p>
       <p>
         Screen capture encompasses the capture of several different types of screen-based surfaces.
-        Collectively, these are referred to as <dfn data-lt="display surface">display
+        Collectively, these are referred to as <dfn class="export" data-lt="display surface">display
         surfaces</dfn>, of which this document defines the following types:
       </p>
       <ul>
-        <li>A <dfn>monitor</dfn> <a>display surface</a> represents a physical display. Some systems
-        have multiple <a>monitor</a>s, which can be identified separately. Multiple <a>monitor</a>s
-        might also be aggregated into a single logical <a>monitor</a>. An aggregated <a>display
+        <li>A <dfn data-dfn-for="display surface" class=export>monitor</dfn> <a>display surface</a> represents a physical display. Some systems
+        have multiple [= display surface/monitor =]s, which can be identified separately. Multiple [= display surface/monitor =]s
+        might also be aggregated into a single logical [= display surface/monitor =]. An aggregated <a>display
         surface</a> is captured as a single {{MediaStreamTrack}}.
         </li>
-        <li>A <dfn data-lt="windows">window</dfn> <a>display surface</a> is a single contiguous
+        <li>A <dfn data-dfn-for="display surface" class=export>window</dfn> <a>display surface</a> is a single contiguous
         surface that is used by a single application.
         </li>
-        <li>A <dfn>browser</dfn> <a>display surface</a> is the rendered form of a
-        [=top-level browsing context=]'s <a data-cite="HTML#viewport">viewport</a>.
+        <li>A single application might have several [= display surface/window =]s available to it, and those can
+        be aggregated into a single <dfn class=export data-dfn-for="display surface">application</dfn> surface, representing all the windows
+        available to that application and therefore presented as a single
+        {{MediaStreamTrack}}.
+        </li>
+        <li>A <dfn data-dfn-for="display surface" class=export>browser</dfn> <a>display surface</a> is the rendered form of a
+        [=browsing context=].
         This is not strictly limited to HTML [[HTML]] documents, though the discussion in this
         document will address some specific concerns with the capture of HTML.
         </li>
@@ -108,11 +113,11 @@
         This document draws a distinction between two variants of each type of display surface:
       </p>
       <ul>
-        <li>A <dfn data-lt="logical display surfaces">logical display surface</dfn> is the surface
+        <li>A <dfn class=export>logical display surface</dfn> is the surface
         that an operating system makes available to an application for the purposes of rendering.
         </li>
-        <li>a <dfn>visible display surface</dfn> is the portion of a [=logical display surface=]
-        that is rendered to a [=monitor=].
+        <li>a <dfn class=export>visible display surface</dfn> is the portion of a [=logical display surface=]
+        that is rendered to a [= display surface/monitor=].
         </li>
       </ul>
       <p>
@@ -121,11 +126,11 @@
         <a>logical display surface</a>.
       </p>
       <p>
-        The <dfn>source pixel ratio</dfn> of a <a>display surface</a> is 1/96th of 1 inch divided
+        The <dfn class=export>source pixel ratio</dfn> of a <a>display surface</a> is 1/96th of 1 inch divided
         by its vertical pixel size.
       </p>
 
-      <p>The <dfn>devicechange</dfn> event is defined in [[GETUSERMEDIA]].</p>
+      <p>The <dfn class=event>devicechange</dfn> event is defined in [[GETUSERMEDIA]].</p>
     </section>
     <section>
       <h2>
@@ -183,10 +188,10 @@
               In the case of audio, the user agent MAY present the end-user with audio sources
               to share. Which choices are available to choose from is up to the user agent, and
               the audio source(s) are not necessarily the same as the video source(s). An audio
-              source may be a particular <a>window</a>, <a>browser</a>, the entire system audio
-              or any combination thereof.
-              Unlike {{MediaDevices/getUserMedia()}} with regards to audio+video, the user agent
-              is allowed not to return audio even if the audio constraint is present. If the user
+              source may be a particular [= display surface/application =], [= display surface/window =], [= display surface/browser =], the
+              entire system audio or any combination thereof. Unlike
+              {{MediaDevices/getUserMedia()}} with regards to audio+video, the user agent is
+              allowed not to return audio even if the audio constraint is present. If the user
               agent knows no audio will be shared for the lifetime of the stream it MUST NOT
               include an audio track in the resulting stream. The user agent MAY accept a
               request for audio and video by only returning a video track in the resulting
@@ -313,7 +318,7 @@
                     unless the user permits it through their interaction with
                     the user agent.</p>
                     <p>User agents are encouraged to warn users against sharing
-                    <a>browser</a> display devices as well as <a>monitor</a>
+                    [= display surface/browser =] display devices as well as [= display surface/monitor =]
                     display devices where browser windows are visible, or
                     otherwise try to discourage their selection on the basis
                     that these represent a significantly higher risk when shared.</p>
@@ -392,7 +397,7 @@
             </p>
             <p>
               The <a>user agent</a> MUST NOT share audio without <a>active user consent</a>, for example
-              if the capture of the video of a <a>window</a> is accompanied by capture of the audio of the
+              if the capture of the video of a [= display surface/window =] is accompanied by capture of the audio of the
               entire system, including applications unrelated to that window.
             </p>
           </dd>
@@ -406,8 +411,8 @@
           A <a>display surface</a> that is being shared may temporarily or permanently become
           inaccessible to the application because of actions taken by the operating system or user
           agent. What makes a <a>display surface</a> considered inaccesible is outside the scope
-          of this specification, but examples MAY include a <a>monitor</a> disconnecting, a
-          <a>window</a> or <a>browser</a> closing or becoming minimized,
+          of this specification, but examples MAY include a [= display surface/monitor =] disconnecting, an
+          [= display surface/application =], [= display surface/window =] or [= display surface/browser =] closing or becoming minimized,
           or due to an incoming call on a phone.
         </p>
         <p class="note">
@@ -428,7 +433,7 @@
         </p>
         <p>
           When a <a>display surface</a> enters an inaccessible state that is permanent (such as
-          the source <a>window</a> closing), the user agent MUST queue a task that
+          the source [= display surface/window=] closing), the user agent MUST queue a task that
           [= track/ended | ends =] the corresponding media track.
         </p>
         <p>
@@ -481,7 +486,7 @@
           </thead>
           <tbody>
             <tr id="def-constraint-width">
-              <td><dfn>width</dfn></td>
+              <td><dfn class=export>width</dfn></td>
               <td>{{ConstrainULong}}</td>
               <td>The width or width range, in pixels. As a capability, max MUST
               reflect the <a>display surface</a>'s width, and min MUST reflect
@@ -489,7 +494,7 @@
               available through downscaling by the user agent.</td>
             </tr>
             <tr id="def-constraint-height">
-              <td><dfn>height</dfn></td>
+              <td><dfn class=export>height</dfn></td>
               <td>{{ConstrainULong}}</td>
               <td>The height or height range, in pixels. As a capability, max
               MUST reflect the <a>display surface</a>'s height, and min MUST
@@ -498,7 +503,7 @@
               </td>
             </tr>
             <tr id="def-constraint-frameRate">
-              <td><dfn>frameRate</dfn></td>
+              <td><dfn class=export>frameRate</dfn></td>
               <td>{{ConstrainDouble}}</td>
               <td>The frame rate (frames per second) or frame rate range. As a
               capability, max MUST reflect the <a>display surface</a>'s frame
@@ -506,7 +511,7 @@
               frame decimation by the user agent.</td>
             </tr>
             <tr id="def-constraint-aspect">
-              <td><dfn>aspectRatio</dfn></td>
+              <td><dfn class=export>aspectRatio</dfn></td>
               <td>{{ConstrainDouble}}</td>
               <td>The exact aspect ratio (width in pixels divided by height in
               pixels, represented as a double rounded to the tenth decimal
@@ -516,7 +521,7 @@
               property immutable from the application viewpoint.</td>
             </tr>
             <tr id="def-constraint-resizeMode">
-              <td><dfn>resizeMode</dfn></td>
+              <td><dfn class=export>resizeMode</dfn></td>
               <td>{{ConstrainDOMString}}</td>
               <td>
                 This string (or each string, when a list) should be one of the members of
@@ -535,7 +540,7 @@
               </td>
             </tr>
             <tr id="def-constraint-displaySurface">
-              <td><dfn>displaySurface</dfn></td>
+              <td><dfn class=export>displaySurface</dfn></td>
               <td>{{ConstrainDOMString}}</td>
               <td>
                 <p>
@@ -562,7 +567,7 @@
               </td>
             </tr>
             <tr id="def-constraint-logicalSurface">
-              <td><dfn>logicalSurface</dfn></td>
+              <td><dfn class=export>logicalSurface</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
                 As a setting, a value of <code>true</code> indicates capture of
@@ -574,7 +579,7 @@
               </td>
             </tr>
             <tr id="def-constraint-cursor">
-              <td><dfn>cursor</dfn></td>
+              <td><dfn class=export>cursor</dfn></td>
               <td>{{ConstrainDOMString}}</td>
               <td>
                 This string (or each string, when a list) should be one of the
@@ -602,7 +607,7 @@
           </thead>
           <tbody>
             <tr id="def-constraint-restrictOwnAudio">
-              <td><dfn>restrictOwnAudio</dfn></td>
+              <td><dfn class=export>restrictOwnAudio</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
                 <p>As a setting, this value indicates whether or not the user
@@ -623,17 +628,17 @@
               </td>
             </tr>
             <tr id="def-constraint-suppressLocalAudioPlayback">
-              <td><dfn>suppressLocalAudioPlayback</dfn></td>
+              <td><dfn class=export>suppressLocalAudioPlayback</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
                 <p>As a setting, this value indicates whether or not the user
                 agent is applying <a>local audio playback suppression</a> to
                 the source.</p>
                 <p>As a constraint, this value is only meaningful if the user
-                selects capturing a [=browser=] [=display surface=]. In that
+                selects capturing a [= display surface/browser=] [=display surface=]. In that
                 case, a value of <code>true</code> indicates that the user
                 agent SHOULD perform <a>local audio playback suppression</a>
-                on the captured [=browser=] [=display surface=].</p>
+                on the captured [= display surface/browser=] [=display surface=].</p>
                 <p>When <dfn>local audio playback suppression</dfn> is applied,
                 the user agent SHOULD stop relaying audio to the local speakers,
                 but that audio MUST still be captured by any ongoing audio-capturing
@@ -642,7 +647,7 @@
                 observe whether it is applying <a>suppressLocalAudioPlayback</a>;
                 not whether that suppression is having an effect (i.e. can't
                 observe if the user is overriding this in the user agent).</p>
-                <p>When a [=browser=] [=display surface=] is subject to multiple
+                <p>When a [= display surface/browser=] [=display surface=] is subject to multiple
                 concurrent captures, <a>local audio playback suppression</a>
                 SHOULD be applied as long as at least one active audio-capturing
                 capture-session is constraining <a>suppressLocalAudioPlayback</a>
@@ -704,7 +709,7 @@
             <p>The max constraint type lets a web application provide a maximum
             envelope for constrainable properties like width and height. This is
             helpful to limit extreme aspect ratios, should the end-user resize a
-            <a>window</a> or <a>browser</a> surface to such an extreme while
+            [= display surface/window =] or [= display surface/browser =] surface to such an extreme while
             it is being captured.</p>
           </div>
           <p>For each constrainable property of positive numeric type in this
@@ -789,7 +794,7 @@
                 </td>
                 <td>
                   The application prefers that options to share system audio be offered to the user
-                  for [=monitor=] [=display surfaces=].
+                  for [=display surface/monitor=] [=display surfaces=].
                 </td>
               </tr>
               <tr>
@@ -892,7 +897,7 @@ dictionary DisplayMediaStreamOptions {
                 </dt>
                 <dd>
                   If present, signals application preference for whether the
-                  [=browser=] [=display surface=] which is associated with
+                  [=display surface/browser=] [=display surface=] which is associated with
                   [=this=]'s [=relevant global object=]'s [=associated Document=]'s
                   [=top-level browsing context=], should be among the choices
                   offered to the user. The user agent MAY ignore this hint.
@@ -1173,7 +1178,7 @@ dictionary DisplayMediaStreamOptions {
                   <dfn id="idl-def-DisplayCaptureSurfaceType.monitor">monitor</dfn>
                 </td>
                 <td>
-                  a [=monitor=] [=display surface=], physical display, or collection of
+                  a [=display surface/monitor=] [=display surface=], physical display, or collection of
                   physical displays
                 </td>
               </tr>
@@ -1182,7 +1187,17 @@ dictionary DisplayMediaStreamOptions {
                   <dfn id="idl-def-DisplayCaptureSurfaceType.window">window</dfn>
                 </td>
                 <td>
-                  a [= window =] [=display surface=], or single application window
+                  a [= display surface/window =] [=display surface=], or single application window
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn id=
+                  "idl-def-DisplayCaptureSurfaceType.application">application</dfn>
+                </td>
+                <td>
+                  an [= display surface/application=] [=display surface=], or entire collection of windows for
+                  an application
                 </td>
               </tr>
               <tr>
@@ -1190,7 +1205,7 @@ dictionary DisplayMediaStreamOptions {
                   <dfn id="idl-def-DisplayCaptureSurfaceType.browser">browser</dfn>
                 </td>
                 <td>
-                  a [=browser=] [=display surface=], or single browser window
+                  a [=display surface/browser=] [=display surface=], or single browser window
                 </td>
               </tr>
             </tbody>
@@ -1297,7 +1312,7 @@ dictionary DisplayMediaStreamOptions {
       <h1 id=feature-policy-integration>Permissions Policy Integration</h1>
       <p>This specification defines a [=policy-controlled feature=]
       identified by the string
-      <code><dfn data-lt="display-capture-feature">"display-capture"</dfn></code>.
+      <dfn class="permission export"><code>"display-capture"</code></dfn>.
       Its [=default allowlist=] is <code>"self"</code>.
       <div class="note">
         <p>A [=document=]'s
@@ -1426,13 +1441,13 @@ dictionary DisplayMediaStreamOptions {
         </p>
         <p>
           Some systems may only capture the <a>logical display surface</a>. Devices with small
-          screens, for instance, do not typically have the concept of a <a>window</a>, and render
+          screens, for instance, do not typically have the concept of a [= display surface/window =], and render
           applications in full screen modes only. These systems might provide a capture of an
           application that is not currently visible, which could be unusable without capturing the
           <a>logical display surface</a>.
         </p>
         <p>
-          When capturing a <a>window</a> or other <a>display surface</a> that is partially transparent,
+          When capturing a [= display surface/window =] or other <a>display surface</a> that is partially transparent,
           any content behind it will not be captured</a>.
         </p>
         <p>
@@ -1450,7 +1465,7 @@ dictionary DisplayMediaStreamOptions {
           privacy and security concern as this may expose additional information about system
           applications, and the set of shared audio sources are not necessarily the same as the set
           of shared video sources. For example, the capture of the video of a
-          <a>window</a> that is accompanied by the audio of the entire system, including applications
+          [= display surface/window =] that is accompanied by the audio of the entire system, including applications
           unrelated to that window, will not be shared without <a>active
           user consent</a>. It is important that the user is aware of what content will be shared,
           including any possible audio. It is strongly encouraged that the user is allowed to give
@@ -1530,8 +1545,8 @@ dictionary DisplayMediaStreamOptions {
           </h2>
           <p>
             <a>Elevated permissions</a> are encouraged as a prerequisite for access to capture of
-            <a>monitor</a> or <a>browser</a> <a>display surfaces</a>. Note that capture of a
-            complete <a>monitor</a> is included because this could include a window from the
+            [= display surface/monitor =] or [= display surface/browser =] <a>display surfaces</a>. Note that capture of a
+            complete [= display surface/monitor =] is included because this could include a window from the
             <a>user agent</a>.
           </p>
           <p>


### PR DESCRIPTION
inspired by https://github.com/w3c/mediacapture-region/pull/41#discussion_r840922809


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/218.html" title="Last updated on Sep 8, 2022, 3:19 PM UTC (44a022c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/218/cd59841...44a022c.html" title="Last updated on Sep 8, 2022, 3:19 PM UTC (44a022c)">Diff</a>