### PR TITLE
Introduce DisplayMediaStreamConstraints.systemAudio

### DIFF
--- a/index.html
+++ b/index.html
@@ -781,7 +781,7 @@
                 </td>
                 <td>
                   The application prefers that options to share system audio be offered to the user
-                  for {{monitor}} display surfaces.
+                  for [=monitor=] [=display surfaces=].
                 </td>
               </tr>
               <tr>

--- a/index.html
+++ b/index.html
@@ -789,7 +789,7 @@
                   <dfn id="idl-def-SystemAudioPreferenceEnum.exclude">exclude</dfn>
                 </td>
                 <td>
-                  The application prefers that the option to share system audio NOT be offered to the user.
+                  The application prefers that options to share system audio not be offered to the user.
                 </td>
               </tr>
             </tbody>

--- a/index.html
+++ b/index.html
@@ -780,7 +780,8 @@
                   <dfn id="idl-def-SystemAudioPreferenceEnum.include">include</dfn>
                 </td>
                 <td>
-                  The application prefers that the option to share system audio be offered to the user.
+                  The application prefers that options to share system audio be offered to the user
+                  for {{monitor}} display surfaces.
                 </td>
               </tr>
               <tr>

--- a/index.html
+++ b/index.html
@@ -758,7 +758,7 @@
         <section>
           <h2><dfn>SystemAudioPreferenceEnum</dfn></h2>
           <p>
-            Describes whether an application invoking {{MediaDevices/getDisplayMedia()}},
+            Describes whether an application invoking {{MediaDevices/getDisplayMedia()}}
             would like the user agent to include system audio among the audio sources
             offered to the user.
           </p>

--- a/index.html
+++ b/index.html
@@ -780,7 +780,7 @@
                   <dfn id="idl-def-SystemAudioPreferenceEnum.include">include</dfn>
                 </td>
                 <td>
-                  The option to share system audio SHOULD be offered to the user.
+                  The application prefers that the option to share system audio be offered to the user.
                 </td>
               </tr>
               <tr>
@@ -788,7 +788,7 @@
                   <dfn id="idl-def-SystemAudioPreferenceEnum.exclude">exclude</dfn>
                 </td>
                 <td>
-                  The option to share system audio SHOULD NOT be offered to the user.
+                  The application prefers that the option to share system audio NOT be offered to the user.
                 </td>
               </tr>
             </tbody>

--- a/index.html
+++ b/index.html
@@ -756,6 +756,45 @@
           </table>
         </section>
         <section>
+          <h2><dfn>SystemAudioPreferenceEnum</dfn></h2>
+          <p>
+            Describes whether an application invoking {{MediaDevices/getDisplayMedia()}},
+            would like the user agent to include system audio among the audio sources
+            offered to the user.
+          </p>
+          <pre class="idl">
+            enum SystemAudioPreferenceEnum {
+              "include",
+              "exclude"
+            };
+          </pre>
+          <table  data-dfn-for="SystemAudioPreferenceEnum" class="simple">
+            <tbody>
+              <tr>
+                <th colspan="2">
+                  Enumeration description
+                </th>
+              </tr>
+              <tr>
+                <td>
+                  <dfn id="idl-def-SystemAudioPreferenceEnum.include">include</dfn>
+                </td>
+                <td>
+                  The option to share system audio SHOULD be offered to the user.
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn id="idl-def-SystemAudioPreferenceEnum.exclude">exclude</dfn>
+                </td>
+                <td>
+                  The option to share system audio SHOULD NOT be offered to the user.
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+        <section>
           <h2>DisplayMediaStreamConstraints</h2>
           <p>The <dfn>DisplayMediaStreamConstraints</dfn> dictionary is used to
           instruct the user agent what sort of {{MediaStreamTrack}}s may be
@@ -767,6 +806,7 @@ dictionary DisplayMediaStreamConstraints {
   (boolean or MediaTrackConstraints) video = true;
   (boolean or MediaTrackConstraints) audio = false;
   SelfCapturePreferenceEnum selfBrowserSurface;
+  SystemAudioPreferenceEnum systemAudio;
 };</pre>
             <section>
               <h2>Dictionary <a class="idlType">DisplayMediaStreamConstraints</a>
@@ -805,6 +845,13 @@ dictionary DisplayMediaStreamConstraints {
                   [=this=]'s [=relevant global object=]'s [=associated Document=]'s
                   [=top-level browsing context=], should be among the choices
                   offered to the user. The user agent MAY ignore this hint.
+                </dd>
+                <dt>
+                  <dfn><code>systemAudio</code></dfn> of type {{SystemAudioPreferenceEnum}}
+                </dt>
+                <dd>
+                  If present, signals whether the application would like system audio
+                  to be included among the possible audio sources offered to the user.
                 </dd>
               </dl>
             </section>


### PR DESCRIPTION
Fixes w3c/mediacapture-screen-share-extensions#7.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/222.html" title="Last updated on May 5, 2022, 3:19 PM UTC (b6d19d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/222/4e0ccb5...eladalon1983:b6d19d6.html" title="Last updated on May 5, 2022, 3:19 PM UTC (b6d19d6)">Diff</a>