### PR TITLE
Add spec-hooks for "actively screen-capturing"

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,17 @@
       </p>
 
       <p>The <dfn>devicechange</dfn> event is defined in [[GETUSERMEDIA]].</p>
+
+      <p>
+        A document is called an <dfn class="export">actively screen-capturing document</dfn>
+        if that document holds a reference to a {{MediaStreamTrackState/"live"}} video track
+        derived from a call to {{MediaDevices/getDisplayMedia}}.
+      </p>
+
+      <p>
+        A user agent is called <dfn class="export">actively screen-capturing</dfn> if any of
+        its [=Document/fully active=] documents is an [=actively screen-capturing document=].
+      </p>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Fixes w3c/mediacapture-main#887.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/eladalon1983/mediacapture-screen-share/pull/224.html" title="Last updated on Jun 2, 2022, 3:08 PM UTC (b1a22c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/224/0222d62...eladalon1983:b1a22c3.html" title="Last updated on Jun 2, 2022, 3:08 PM UTC (b1a22c3)">Diff</a>