### PR TITLE
Remove unhelpful caption

### DIFF
--- a/index.html
+++ b/index.html
@@ -1227,7 +1227,6 @@ dictionary DisplayMediaStreamOptions {
 };</pre>
           <table  data-dfn-for="DisplayCaptureSurfaceType"
               class="simple">
-          <caption>{{DisplayCaptureSurfaceType}} Enumeration description</caption>
             <thead>
               <tr>
             <th>Enum value</th><th>Description</th>
@@ -1278,7 +1277,6 @@ dictionary DisplayMediaStreamOptions {
 };</pre>
           <table  data-dfn-for="CursorCaptureConstraint"
               class="simple">
-          <caption>{{CursorCaptureConstraint}} Enumeration description</caption>
           <thead>
               <tr>
             <th>Enum value</th><th>Description</tH>

--- a/index.html
+++ b/index.html
@@ -790,7 +790,6 @@
             };
           </pre>
           <table  data-dfn-for="SelfCapturePreferenceEnum" class="simple">
-          <caption>{{SelfCapturePreferenceEnum}} Enumeration description</caption>
             <thead>
               <tr>
             <th>Enum value</th><th>Description</th>


### PR DESCRIPTION
Other enums in that area do not employ a caption. We should either caption all or none. I vote none, as I don't see how it helps, given how short and straight-forward these enums are.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/239.html" title="Last updated on Oct 6, 2022, 2:15 PM UTC (56e2220)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/239/7857efe...56e2220.html" title="Last updated on Oct 6, 2022, 2:15 PM UTC (56e2220)">Diff</a>