### PR TITLE
Remove unused reference to MediaStreamConstraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,9 +80,8 @@
         Terminology
       </h2>
       <p>
-        This document uses the definition of {{MediaStream}}, {{MediaStreamTrack}},
-        {{MediaStreamConstraints}} and {{ConstrainablePattern}}
-        from [[!GETUSERMEDIA]].
+        This document uses the definition of {{MediaStream}}, {{MediaStreamTrack}}
+        and {{ConstrainablePattern}} from [[!GETUSERMEDIA]].
       </p>
       <p>
         Screen capture encompasses the capture of several different types of screen-based surfaces.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/242.html" title="Last updated on Oct 12, 2022, 3:50 PM UTC (47f2659)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/242/15bf8bd...47f2659.html" title="Last updated on Oct 12, 2022, 3:50 PM UTC (47f2659)">Diff</a>