### PR TITLE
Remove obsolete "application" DisplayCaptureSurfaceType

### DIFF
--- a/index.html
+++ b/index.html
@@ -1256,16 +1256,6 @@ dictionary DisplayMediaStreamOptions {
               </tr>
               <tr>
                 <td>
-                  <dfn id=
-                  "idl-def-DisplayCaptureSurfaceType.application">application</dfn>
-                </td>
-                <td>
-                  an [= display surface/application=] [=display surface=], or entire collection of windows for
-                  an application
-                </td>
-              </tr>
-              <tr>
-                <td>
                   <dfn id="idl-def-DisplayCaptureSurfaceType.browser">browser</dfn>
                 </td>
                 <td>

--- a/index.html
+++ b/index.html
@@ -98,11 +98,6 @@
         <li>A <dfn data-dfn-for="display surface" class=export>window</dfn> <a>display surface</a> is a single contiguous
         surface that is used by a single application.
         </li>
-        <li>A single application might have several [= display surface/window =]s available to it, and those can
-        be aggregated into a single <dfn class=export data-dfn-for="display surface">application</dfn> surface, representing all the windows
-        available to that application and therefore presented as a single
-        {{MediaStreamTrack}}.
-        </li>
         <li>A <dfn data-dfn-for="display surface" class=export>browser</dfn> <a>display surface</a> is the rendered form of a
         [=browsing context=].
         This is not strictly limited to HTML [[HTML]] documents, though the discussion in this
@@ -188,8 +183,8 @@
               In the case of audio, the user agent MAY present the end-user with audio sources
               to share. Which choices are available to choose from is up to the user agent, and
               the audio source(s) are not necessarily the same as the video source(s). An audio
-              source may be a particular [= display surface/application =], [= display surface/window =], [= display surface/browser =], the
-              entire system audio or any combination thereof. Unlike
+              source may be a particular [= display surface/window =], [= display surface/browser =],
+              the entire system audio or any combination thereof. Unlike
               {{MediaDevices/getUserMedia()}} with regards to audio+video, the user agent is
               allowed not to return audio even if the audio constraint is present. If the user
               agent knows no audio will be shared for the lifetime of the stream it MUST NOT
@@ -434,8 +429,8 @@
           A <a>display surface</a> that is being shared may temporarily or permanently become
           inaccessible to the application because of actions taken by the operating system or user
           agent. What makes a <a>display surface</a> considered inaccesible is outside the scope
-          of this specification, but examples MAY include a [= display surface/monitor =] disconnecting, an
-          [= display surface/application =], [= display surface/window =] or [= display surface/browser =] closing or becoming minimized,
+          of this specification, but examples MAY include a [= display surface/monitor =] disconnecting,
+          [= display surface/window =] or [= display surface/browser =] closing or becoming minimized,
           or due to an incoming call on a phone.
         </p>
         <p class="note">


### PR DESCRIPTION
PTAL


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-screen-share/pull/243.html" title="Last updated on Oct 13, 2022, 2:37 PM UTC (f826247)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/243/15bf8bd...beaufortfrancois:f826247.html" title="Last updated on Oct 13, 2022, 2:37 PM UTC (f826247)">Diff</a>