### PR TITLE
Editorial: Remove </a> without <a>

### DIFF
--- a/index.html
+++ b/index.html
@@ -1495,7 +1495,7 @@ dictionary DisplayMediaStreamOptions {
         </p>
         <p>
           When capturing a [= display surface/window =] or other <a>display surface</a> that is partially transparent,
-          any content behind it will not be captured</a>.
+          any content behind it will not be captured.
         </p>
         <p>
           There is a risk that the user prompt be exposed to the web page for a short amount of time


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/244.html" title="Last updated on Oct 13, 2022, 2:51 PM UTC (5451b94)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/244/1fc5e57...5451b94.html" title="Last updated on Oct 13, 2022, 2:51 PM UTC (5451b94)">Diff</a>