### PR TITLE
Add web platform tests badges to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# Screen Capture 
+
+[![WPT Chrome](https://wpt-badge.glitch.me/?product=chrome&prefix=/screen-capture/)](https://wpt.fyi/results/screen-capture)
+[![WPT Firefox](https://wpt-badge.glitch.me/?product=firefox&prefix=/screen-capture/)](https://wpt.fyi/results/screen-capture)
+[![WPT Safari](https://wpt-badge.glitch.me/?product=safari&prefix=/screen-capture/)](https://wpt.fyi/results/screen-capture)
 
 This work is currently licensed under a Creative Commons Attribution-NoDerivatives 4.0
 International (CC BY-ND 4.0) License. See


### PR DESCRIPTION
This PR adds web platform tests badges to README.md file as in https://github.com/w3c/mediacapture-handle and https://github.com/w3c/picture-in-picture for instance.