### PR TITLE
Add missing suppressLocalAudioPlayback setting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1431,8 +1431,8 @@ dictionary DisplayMediaStreamOptions {
             </dt>
             <dd>
               <p>
-                Indicates whether the <a href="#dfn-suppresslocalaudioplayback">suppressLocalAudioPlayback</a>
-                constraint is applied (<code>true</code>) or not (<code>false</code>).
+                Indicates whether or not the user agent is applying
+                [=local audio playback suppression=] to the source.
               </p>
             </dd>
           </dl>

--- a/index.html
+++ b/index.html
@@ -1425,6 +1425,15 @@ dictionary DisplayMediaStreamOptions {
                 constraint is applied (<code>true</code>) or not (<code>false</code>).
               </p>
             </dd>
+            <dt>
+               <dfn>suppressLocalAudioPlayback</dfn> of type {{boolean}}
+            </dt>
+            <dd>
+              <p>
+                Indicates whether the <a href="#dfn-suppressLocalAudioPlayback">suppressLocalAudioPlayback</a>
+                constraint is applied (<code>true</code>) or not (<code>false</code>).
+              </p>
+            </dd>
           </dl>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -701,8 +701,8 @@
               <td><dfn class=export>suppressLocalAudioPlayback</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
-                <p>As a setting, this value indicates whether or not the constraint
-                for <a>local audio playback suppression</a> is applied to
+                <p>As a setting, this value indicates whether or not the user
+                agent is applying <a>local audio playback suppression</a> to
                 the source.</p>
                 <p>As a constraint, this value is only meaningful if the user
                 selects capturing a [= display surface/browser=] [=display surface=]. In that

--- a/index.html
+++ b/index.html
@@ -1431,7 +1431,7 @@ dictionary DisplayMediaStreamOptions {
             </dt>
             <dd>
               <p>
-                Indicates whether or not the user agent is applying
+                Indicates whether or not the application instructed the user agent to apply
                 [=local audio playback suppression=] to the source.
               </p>
             </dd>

--- a/index.html
+++ b/index.html
@@ -701,9 +701,9 @@
               <td><dfn class=export>suppressLocalAudioPlayback</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
-                <p>As a setting, this value indicates whether or not the user
-                agent is applying <a>local audio playback suppression</a> to
-                the source.</p>
+                <p>As a setting, this value indicates whether or not the application
+                instructed the user agent to apply <a>local audio playback suppression</a>
+                to the source.</p>
                 <p>As a constraint, this value is only meaningful if the user
                 selects capturing a [= display surface/browser=] [=display surface=]. In that
                 case, a value of <code>true</code> indicates that the user

--- a/index.html
+++ b/index.html
@@ -701,8 +701,8 @@
               <td><dfn class=export>suppressLocalAudioPlayback</dfn></td>
               <td>{{ConstrainBoolean}}</td>
               <td>
-                <p>As a setting, this value indicates whether or not the user
-                agent is applying <a>local audio playback suppression</a> to
+                <p>As a setting, this value indicates whether or not the constraint
+                for <a>local audio playback suppression</a> is applied to
                 the source.</p>
                 <p>As a constraint, this value is only meaningful if the user
                 selects capturing a [= display surface/browser=] [=display surface=]. In that

--- a/index.html
+++ b/index.html
@@ -1385,6 +1385,7 @@ dictionary DisplayMediaStreamOptions {
   boolean logicalSurface;
   DOMString cursor;
   boolean restrictOwnAudio;
+  boolean suppressLocalAudioPlayback;
 };</pre>
           <dl data-link-for="MediaTrackSettings" data-dfn-for="MediaTrackSettings" class=
           "dictionary-members">

--- a/index.html
+++ b/index.html
@@ -1430,7 +1430,7 @@ dictionary DisplayMediaStreamOptions {
             </dt>
             <dd>
               <p>
-                Indicates whether the <a href="#dfn-suppressLocalAudioPlayback">suppressLocalAudioPlayback</a>
+                Indicates whether the <a href="#dfn-suppresslocalaudioplayback">suppressLocalAudioPlayback</a>
                 constraint is applied (<code>true</code>) or not (<code>false</code>).
               </p>
             </dd>


### PR DESCRIPTION
I've noticed `suppressLocalAudioPlayback` setting was missing in https://w3c.github.io/mediacapture-screen-share/#extensions-to-mediatracksettings while https://w3c.github.io/mediacapture-screen-share/#dfn-suppresslocalaudioplayback says: 
> As a setting, this value indicates whether or not the user agent is applying local audio playback suppression to the source.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/beaufortfrancois/mediacapture-screen-share/pull/254.html" title="Last updated on Nov 14, 2022, 8:36 AM UTC (231cb3d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/254/dc44099...beaufortfrancois:231cb3d.html" title="Last updated on Nov 14, 2022, 8:36 AM UTC (231cb3d)">Diff</a>