### PR TITLE
Fix default allowlist link that broke.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1634,7 +1634,7 @@ dictionary DisplayMediaStreamOptions {
       <p>This specification defines a [=policy-controlled feature=]
       identified by the string
       <dfn class="permission export"><code>"display-capture"</code></dfn>.
-      Its [=default allowlist=] is <code>"self"</code>.
+      Its [=policy-controlled feature/default allowlist=] is <code>"self"</code>.
       <div class="note">
         <p>A [=document=]'s
         [=Document/permissions policy=]


### PR DESCRIPTION
Fixes respec errors.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jan 12, 2023, 7:17 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL](https://labs.w3.org/spec-generator/?type=respec&url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fmediacapture-screen-share%2F67b1b8b0e0b7b498afa514c289ecd3019b594a5f%2Findex.html%3FisPreview%3Dtrue)

```

😭  Sorry, there was an error generating the HTML. Please report this issue!
Specification: http://labs.w3.org/spec-generator/uploads/QOD28b/index.html?isPreview=true%3FisPreview%3Dtrue&publishDate=2023-01-12
ReSpec version: 32.6.1
File a bug: https://github.com/w3c/respec/
Error: Error: Evaluation failed: Timeout: document.respec.ready didn't resolve in 28343ms.
    at ExecutionContext._ExecutionContext_evaluate (/u/spec-generator/node_modules/puppeteer-core/lib/cjs/puppeteer/common/ExecutionContext.js:229:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async ExecutionContext.evaluate (/u/spec-generator/node_modules/puppeteer-core/lib/cjs/puppeteer/common/ExecutionContext.js:107:16)
    at async generateHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:221:12)
    at async toHTML (/u/spec-generator/node_modules/respec/tools/respecDocWriter.js:92:18)
    at async Object.generate [as respec] (file:///u/spec-generator/generators/respec.js:15:44)
    at async file:///u/spec-generator/server.js:252:48

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/mediacapture-screen-share%23256.)._
</details>
