### PR TITLE
Update how FocusChangeDisabled is set to true in case of change of focus

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,13 +424,12 @@
                     </p>
                   </li>
                   <li>
-                    <p>Let <var>topContext</var> be the <a>current settings object</a>'s's [=relevant global object=]'s
-                      [=associated Document=]'s [=top-level browsing context=].</p>
+                    <p>Let <var>toplevelTraversable</var> be the <a>current settings object</a>'s's [=relevant global object=]'s
+                      [=navigable=]'s [=top-level traversable=].</p>
                   </li>
                   <li>
-                    <p>Start listening to <var>topContext</var>'s change of <a data-cite="!HTML/#gains-focus">focus</a>.
-                      Whenever <var>topContext</var> is losing <a data-cite="!HTML/#gains-focus">focus</a>, stop listening
-                      to <var>topContext</var>'s change of <a data-cite="!HTML/#gains-focus">focus</a> and
+                    <p>Listen to <var>toplevelTraversable</var>'s change of <a data-cite="!HTML/#system-focus">system focus</a>.</p>
+                    <p>The first time <var>toplevelTraversable</var> is losing <a data-cite="!HTML/#system-focus">focus</a>,
                       queue a global task on the <a data-cite="!HTML/#user-interaction-task-source">user interaction task source</a>
                       given <a>current settings object</a>'s [=relevant global object=] to run the following step:
                       <ol>

--- a/index.html
+++ b/index.html
@@ -424,6 +424,29 @@
                     </p>
                   </li>
                   <li>
+                    <p>Let <var>topContext</var> be the <a>current settings object</a>'s's [=relevant global object=]'s
+                      [=associated Document=]'s [=top-level browsing context=].</p>
+                  </li>
+                  <li>
+                    <p>Start listening to <var>topContext</var>'s change of <a data-cite="!HTML/#gains-focus">focus</a>.
+                      Whenever <var>topContext</var> is losing <a data-cite="!HTML/#gains-focus">focus</a>, stop listening
+                      to <var>topContext</var>'s change of <a data-cite="!HTML/#gains-focus">focus</a> and
+                      queue a global task on the <a data-cite="!HTML/#user-interaction-task-source">user interaction task source</a>
+                      given <a>current settings object</a>'s [=relevant global object=] to run the following step:
+                      <ol>
+                        <li><p>Set <var>controller</var>.{{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.</p></li>
+                      </ol>
+                    </p>
+                    <p class="note">
+                      These steps ensure {{CaptureController}} will not override explicit focus actions made by the user,
+                      typically if a user decides to switch to another surface shortly after starting capture.
+                      This algorithm describes what to do for surface pickers implemented by the <a>user agent</a> but the same
+                      requirement applies to surface pickers implemented outside of the <a>user agent</a>,
+                      where the loss of capturing document focus is not necessarily the signal triggering setting
+                      {{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.
+                    </p>
+                  </li>
+                  <li>
                     <p><em>Permission Failure</em>: [=Reject=]
                     <var>p</var> with a new {{DOMException}}
                     object whose {{DOMException/name}} attribute has the

--- a/index.html
+++ b/index.html
@@ -397,6 +397,28 @@
                   <li>
                     If <var>controller</var> is not <code>null</code>, run the following steps:
                     <ol>
+                    <li>
+                      <p>Let <var>toplevelTraversable</var> be the <a>current settings object</a>'s's [=relevant global object=]'s
+                        [=navigable=]'s [=top-level traversable=].</p>
+                    </li>
+                    <li>
+                      <p>Listen to <var>toplevelTraversable</var>'s change of <a data-cite="!HTML/#system-focus">system focus</a>.</p>
+                      <p>The first time <var>toplevelTraversable</var> is losing <a data-cite="!HTML/#system-focus">focus</a>,
+                        queue a global task on the <a data-cite="!HTML/#user-interaction-task-source">user interaction task source</a>
+                        given <a>current settings object</a>'s [=relevant global object=] to run the following step:
+                        <ol>
+                          <li><p>Set <var>controller</var>.{{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.</p></li>
+                        </ol>
+                      </p>
+                      <p class="note">
+                        These steps ensure {{CaptureController}} will not override explicit focus actions made by the user,
+                        typically if a user decides to switch to another surface shortly after starting capture.
+                        This algorithm describes what to do for surface pickers implemented by the <a>user agent</a> but the same
+                        requirement applies to surface pickers implemented outside of the <a>user agent</a>,
+                        where the loss of capturing document focus is not necessarily the signal triggering setting
+                        {{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.
+                      </p>
+                    </li>
                       <li>
                         <p>
                           Set <var>controller</var>.{{CaptureController/[[Source]]}}
@@ -421,28 +443,6 @@
                     <p>
                       <a>Resolve</a> <var>p</var> with <var>stream</var> and
                       abort these steps. 
-                    </p>
-                  </li>
-                  <li>
-                    <p>Let <var>toplevelTraversable</var> be the <a>current settings object</a>'s's [=relevant global object=]'s
-                      [=navigable=]'s [=top-level traversable=].</p>
-                  </li>
-                  <li>
-                    <p>Listen to <var>toplevelTraversable</var>'s change of <a data-cite="!HTML/#system-focus">system focus</a>.</p>
-                    <p>The first time <var>toplevelTraversable</var> is losing <a data-cite="!HTML/#system-focus">focus</a>,
-                      queue a global task on the <a data-cite="!HTML/#user-interaction-task-source">user interaction task source</a>
-                      given <a>current settings object</a>'s [=relevant global object=] to run the following step:
-                      <ol>
-                        <li><p>Set <var>controller</var>.{{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.</p></li>
-                      </ol>
-                    </p>
-                    <p class="note">
-                      These steps ensure {{CaptureController}} will not override explicit focus actions made by the user,
-                      typically if a user decides to switch to another surface shortly after starting capture.
-                      This algorithm describes what to do for surface pickers implemented by the <a>user agent</a> but the same
-                      requirement applies to surface pickers implemented outside of the <a>user agent</a>,
-                      where the loss of capturing document focus is not necessarily the signal triggering setting
-                      {{CaptureController/[[FocusChangeDisabled]]}} to <code>true</code>.
                     </p>
                   </li>
                   <li>


### PR DESCRIPTION
The change covers potential race conditions where the change of focus task is already enqueued at the time the getDisplayMedia promise is resolved. Add a note to talk about the requirement behind these steps and that it should apply to any type of picker, whether user agent level or OS level.

Fixes https://github.com/w3c/mediacapture-screen-share/issues/262


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-screen-share/pull/264.html" title="Last updated on Jul 6, 2023, 6:04 AM UTC (286a32d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/264/30d0ea6...youennf:286a32d.html" title="Last updated on Jul 6, 2023, 6:04 AM UTC (286a32d)">Diff</a>