### PR TITLE
Explicitly create MediaStream tracks in getDisplayMedia algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -486,7 +486,7 @@
                         with <var>source</var> and <var>mediaDevices</var>.</p>
                       </li>
                       <li>
-                        <p>Add <var>track</var> to <var>stream</var> track's set.</p>
+                        <p>Add <var>track</var> to <var>stream</var>'s track set.</p>
                       </li>
                       <li>
                         <p>[=Tie track source to MediaDevices=] with <var>source</var> and <var>mediaDevices</var>.</p>

--- a/index.html
+++ b/index.html
@@ -244,6 +244,11 @@
 
           <ol>
             <li>
+              <p>Let <var>mediaDevices</var> be [=this=].</p>
+            </li>
+
+
+            <li>
               <p>Let <var>controller</var> be
               <var>options</var>.<code>controller</code> if present, or
               <code>null</code> otherwise.</p>
@@ -468,8 +473,25 @@
 
 
                 <li>
-                  <p>Let <var>stream</var> be the {{MediaStream}} object for
-                  which the user granted permission.</p>
+                  <p>Let <var>stream</var> be a {{MediaStream}} object.</p>
+                </li>
+
+                <li>
+                  <p>For each <var>source</var> that the user granted permission
+                  to, run the following steps:</p>
+                    <ol>
+                      <li>
+                        <p>Let <var>track</var> be the result of [=create a
+                        MediaStreamTrack|creating a MediaStreamTrack=]
+                        with <var>source</var> and <var>mediaDevices</var>.</p>
+                      </li>
+                      <li>
+                        <p>Add <var>track</var> to <var>stream</var> track's set.</p>
+                      </li>
+                      <li>
+                        <p>[=Tie track source to MediaDevices=] with <var>source</var> and <var>mediaDevices</var>.</p>
+                      </li>
+                    </ol>
                 </li>
 
 


### PR DESCRIPTION
Fixes #293


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-screen-share/pull/294.html" title="Last updated on Jan 18, 2024, 3:11 PM UTC (d083abb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/294/8a068bb...youennf:d083abb.html" title="Last updated on Jan 18, 2024, 3:11 PM UTC (d083abb)">Diff</a>