### PR TITLE
Fix a couple of links to Media Capture and Streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -628,20 +628,20 @@
 
 
       <p>When <a>display surface</a> enters an inaccessible state that is not
-      necessarily permanent, the user agent MUST queue a task that [= set a
+      necessarily permanent, the user agent MUST queue a task that [= MediaStreamTrack/set a
       track's muted state|sets the muted state =] of the corresponding media
       track to <code>true</code>.</p>
 
 
       <p>When <a>display surface</a> exits an inaccessible state and becomes
-      accessible, the user agent MUST queue a task that [= set a track's muted
+      accessible, the user agent MUST queue a task that [= MediaStreamTrack/set a track's muted
       state|sets the muted state =] of the corresponding media track to
       <code>false</code>.</p>
 
 
       <p>When a <a>display surface</a> enters an inaccessible state that is
       permanent (such as the source [= display surface/window=] closing), the
-      user agent MUST queue a task that [= track/ended | ends =] the
+      user agent MUST queue a task that [= MediaStreamTrack/ended | ends =] the
       corresponding media track.</p>
 
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/305.html" title="Last updated on Jun 10, 2024, 3:40 PM UTC (51ccd56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/305/d0d9478...51ccd56.html" title="Last updated on Jun 10, 2024, 3:40 PM UTC (51ccd56)">Diff</a>