### PR TITLE
Add deviceId as settings and constraints for screen share video tracks.

### DIFF
--- a/index.html
+++ b/index.html
@@ -793,6 +793,26 @@
           </tr>
 
 
+          <tr id="def-constraint-deviceId">
+            <td><dfn class="export">deviceId</dfn>
+            </td>
+
+            <td>{{DOMString}}</td>
+
+            <td>
+              The identifier of the surface being captured.
+
+              <p>As a setting, identifies the [=display surface=] that
+              is being captured. The identifier MUST be uniquely generated for
+              each document.</p>
+
+              <p>As a capability, the setting value MUST be the lone value
+              present, rendering this property immutable from the application
+              viewpoint.</p>
+            </td>
+          </tr>
+
+
           <tr id="def-constraint-displaySurface">
             <td><dfn class="export">displaySurface</dfn>
             </td>

--- a/index.html
+++ b/index.html
@@ -804,7 +804,7 @@
 
               <p>As a setting, identifies the [=display surface=] that
               is being captured. The identifier MUST be uniquely generated for
-              each document.</p>
+              each [=document=].</p>
 
               <p>As a capability, the setting value MUST be the lone value
               present, rendering this property immutable from the application


### PR DESCRIPTION
Fixes https://github.com/w3c/mediacapture-screen-share/issues/308


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youennf/mediacapture-screen-share/pull/310.html" title="Last updated on Dec 19, 2024, 3:27 PM UTC (0d31e54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/310/d864164...youennf:0d31e54.html" title="Last updated on Dec 19, 2024, 3:27 PM UTC (0d31e54)">Diff</a>