### PR TITLE
Editorial: Export CaptureController's internal slot definitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,7 +1166,7 @@
             Create a new {{CaptureController}} object with the following
             internal slots:
 
-            <table class="simple">
+            <table class="simple" data-dfn-for="CaptureController" data-dfn-type="attribute">
               <thead>
                 <tr>
                   <th>Internal Slot</th>

--- a/index.html
+++ b/index.html
@@ -1166,7 +1166,7 @@
             Create a new {{CaptureController}} object with the following
             internal slots:
 
-            <table class="simple" data-dfn-for="CaptureController" data-dfn-type="attribute">
+            <table class="simple" data-dfn-for="CaptureController">
               <thead>
                 <tr>
                   <th>Internal Slot</th>
@@ -1180,7 +1180,7 @@
 
               <tbody>
                 <tr>
-                  <td><dfn class="export">[[\IsBound]]</dfn>
+                  <td><dfn class="attribute">[[\IsBound]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1192,7 +1192,7 @@
 
 
                 <tr>
-                  <td><dfn class="export">[[\Source]]</dfn>
+                  <td><dfn class="attribute">[[\Source]]</dfn>
                   </td>
 
                   <td><code>null</code>
@@ -1203,7 +1203,7 @@
 
 
                 <tr>
-                  <td><dfn class="export">[[\DisplaySurfaceType]]</dfn>
+                  <td><dfn class="attribute">[[\DisplaySurfaceType]]</dfn>
                   </td>
 
                   <td><code>null</code>
@@ -1215,7 +1215,7 @@
 
 
                 <tr>
-                  <td><dfn class="export">[[\FocusChangeDisabled]]</dfn>
+                  <td><dfn class="attribute">[[\FocusChangeDisabled]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1227,7 +1227,7 @@
 
 
                 <tr>
-                  <td><dfn class="export">[[\FocusDecisionFinalized]]</dfn>
+                  <td><dfn class="attribute">[[\FocusDecisionFinalized]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1238,7 +1238,7 @@
 
 
                 <tr>
-                  <td><dfn class="export">[[\FocusBehavior]]</dfn>
+                  <td><dfn class="attribute">[[\FocusBehavior]]</dfn>
                   </td>
 
                   <td><code>null</code>

--- a/index.html
+++ b/index.html
@@ -1180,7 +1180,7 @@
 
               <tbody>
                 <tr>
-                  <td><dfn>[[\IsBound]]</dfn>
+                  <td><dfn class="export">[[\IsBound]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1192,7 +1192,7 @@
 
 
                 <tr>
-                  <td><dfn>[[\Source]]</dfn>
+                  <td><dfn class="export">[[\Source]]</dfn>
                   </td>
 
                   <td><code>null</code>
@@ -1203,7 +1203,7 @@
 
 
                 <tr>
-                  <td><dfn>[[\DisplaySurfaceType]]</dfn>
+                  <td><dfn class="export">[[\DisplaySurfaceType]]</dfn>
                   </td>
 
                   <td><code>null</code>
@@ -1215,7 +1215,7 @@
 
 
                 <tr>
-                  <td><dfn>[[\FocusChangeDisabled]]</dfn>
+                  <td><dfn class="export">[[\FocusChangeDisabled]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1227,7 +1227,7 @@
 
 
                 <tr>
-                  <td><dfn>[[\FocusDecisionFinalized]]</dfn>
+                  <td><dfn class="export">[[\FocusDecisionFinalized]]</dfn>
                   </td>
 
                   <td><code>false</code>
@@ -1238,7 +1238,7 @@
 
 
                 <tr>
-                  <td><dfn>[[\FocusBehavior]]</dfn>
+                  <td><dfn class="export">[[\FocusBehavior]]</dfn>
                   </td>
 
                   <td><code>null</code>


### PR DESCRIPTION
By exporting these, we ensure other specs can refer to them more easily, without needing data-cite.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/313.html" title="Last updated on Jan 24, 2025, 10:37 AM UTC (cfae727)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/313/12c421d...cfae727.html" title="Last updated on Jan 24, 2025, 10:37 AM UTC (cfae727)">Diff</a>