### PR TITLE
getDisplayMedia's promise confers transient activation when resolved

### DIFF
--- a/index.html
+++ b/index.html
@@ -541,7 +541,7 @@
                     </li>
                     <li>
                       Set the <a data-cite="html/#last-activation-timestamp">last activation timestamp</a>
-                      to the <a data-cite="hr-time#dfn-current-high-resolution-time">current high resolution time</a>.
+                      to the [=current high resolution time=].
                     </li>
                     <li>
                       <p>[=Resolve=] <var>p</var> with <var>stream</var>.</p>

--- a/index.html
+++ b/index.html
@@ -540,6 +540,14 @@
                       </ol>
                     </li>
                     <li>
+                      Set the <a data-cite="html/#last-activation-timestamp">last activation timestamp</a>
+                      to the <a data-cite="hr-time#dfn-current-high-resolution-time">current high resolution time</a>.
+                    </li>
+                    <li>
+                      Set the <a data-cite="html/#last-activation-timestamp">last activation timestamp</a>
+                      to the <a data-cite="hr-time#dfn-current-high-resolution-time">current high resolution time</a>.
+                    </li>
+                    <li>
                       <p>[=Resolve=] <var>p</var> with <var>stream</var>.</p>
                     </li>
                   </ol>
@@ -885,7 +893,7 @@
 
             <td>{{double}}</td>
 
-            <td>As a setting, it is the result of dividing the size of a 
+            <td>As a setting, it is the result of dividing the size of a
             <a data-xref-type="css-value" data-xref-for="<length>" data-lt="px">CSS pixel</a>
             at a <a href="https://drafts.csswg.org/cssom-view/#page-zoom">page zoom</a>
             of 1.0 and using a
@@ -1092,7 +1100,7 @@
               "focus-capturing-application",
               "focus-captured-surface",
               "no-focus-change"
-            };    
+            };
           </pre>
 
         <table data-dfn-for="CaptureStartFocusBehavior" class="simple">

--- a/index.html
+++ b/index.html
@@ -544,10 +544,6 @@
                       to the <a data-cite="hr-time#dfn-current-high-resolution-time">current high resolution time</a>.
                     </li>
                     <li>
-                      Set the <a data-cite="html/#last-activation-timestamp">last activation timestamp</a>
-                      to the <a data-cite="hr-time#dfn-current-high-resolution-time">current high resolution time</a>.
-                    </li>
-                    <li>
                       <p>[=Resolve=] <var>p</var> with <var>stream</var>.</p>
                     </li>
                   </ol>

--- a/screenshare.js
+++ b/screenshare.js
@@ -40,7 +40,7 @@ var respecConfig = {
     { name: "Jan-Ivar Bruaroey", company: "Mozilla", w3cid: 79152},
     { name: "Elad Alon", company: "Google", w3cid: 118124}
   ],
-  
+
   formerEditors: [
     { name: "Martin Thomson", company: "Mozilla", w3cid: 68503 },
     { name: "Keith Griffin", company: "Cisco", w3cid: 65606 },
@@ -59,7 +59,7 @@ var respecConfig = {
 
   // name of the WG
   group: "webrtc",
-  xref: ["html", "infra", "permissions", "permissions-policy", "dom", "mediacapture-streams", "webidl", "cssom-view", "css-values"],
+  xref: ["html", "infra", "permissions", "permissions-policy", "dom", "mediacapture-streams", "webidl", "cssom-view", "css-values", "hr-time"],
   // name (without the @w3.org) of the public mailing to which comments are due
   wgPublicList: "public-webrtc",
 

--- a/screenshare.js
+++ b/screenshare.js
@@ -59,7 +59,7 @@ var respecConfig = {
 
   // name of the WG
   group: "webrtc",
-  xref: ["html", "infra", "permissions", "permissions-policy", "dom", "mediacapture-streams", "webidl", "cssom-view", "css-values"],
+  xref: ["html", "infra", "permissions", "permissions-policy", "dom", "mediacapture-streams", "webidl", "cssom-view", "css-values", "hr-time"],
   // name (without the @w3.org) of the public mailing to which comments are due
   wgPublicList: "public-webrtc",
 


### PR DESCRIPTION
When invoked, getDisplayMedia() returns a promise. If the user chooses to share a tab, a window or a screen, that promise is resolved. We specify that when that happens, this confers renewed transient activation in the document which has called getDisplayMedia().


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/pull/322.html" title="Last updated on May 22, 2025, 2:34 PM UTC (314508a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/322/8d0f388...314508a.html" title="Last updated on May 22, 2025, 2:34 PM UTC (314508a)">Diff</a>