### PR TITLE
Clarifies the relationship between the systemAudio option and monitor display surfaces.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1476,7 +1476,8 @@
         <p>Describes whether an application invoking
         {{MediaDevices/getDisplayMedia()}} would like the user agent to include
         system audio among the audio sources offered to the user for
-        [=display surface/monitor=] [=display surfaces=].
+        [=display surface/monitor=] [=display surfaces=]. Does not apply to any
+        other type of [=display surface=].
 
         <pre class="idl">
             enum SystemAudioPreferenceEnum {

--- a/index.html
+++ b/index.html
@@ -1475,7 +1475,8 @@
 
         <p>Describes whether an application invoking
         {{MediaDevices/getDisplayMedia()}} would like the user agent to include
-        system audio among the audio sources offered to the user.</p>
+        system audio among the audio sources offered to the user for
+        [=display surface/monitor=] [=display surfaces=].
 
         <pre class="idl">
             enum SystemAudioPreferenceEnum {
@@ -1508,7 +1509,8 @@
               </td>
 
               <td>The application prefers that options to share system audio
-              not be offered to the user.</td>
+              not be offered to the user for [=display surface/monitor=]
+              [=display surfaces=].</td>
             </tr>
           </tbody>
         </table>
@@ -1767,7 +1769,8 @@ dictionary DisplayMediaStreamOptions {
 
               <dd>If present, signals whether the application would like system
               audio to be included among the possible audio sources offered to
-              the user. The user agent MAY ignore this hint.</dd>
+              the user for [=display surface/monitor=] [=display surfaces=]. The
+              user agent MAY ignore this hint.</dd>
 
 
               <dt><dfn><code>windowAudio</code></dfn> of type


### PR DESCRIPTION
Clarifies the relationship between the `systemAudio` option and monitor display surfaces.

The description of the `SystemAudioPreferenceEnum`'s "include" enum already specifies that `systemAudio` is linked to monitor display surfaces. This update aims to further clarify this existing relationship within the specification.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/drkron/mediacapture-screen-share/pull/327.html" title="Last updated on Jul 17, 2025, 2:31 PM UTC (5181680)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/327/bbea0cc...drkron:5181680.html" title="Last updated on Jul 17, 2025, 2:31 PM UTC (5181680)">Diff</a>