### PR TITLE
Add algorithm for browser automation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,11 @@
 
 
             <li>
+              <p>Let <var>options</var> be the method's first argument.</p>
+            </li>
+
+
+            <li>
               <p>Let <var>controller</var> be
               <var>options</var>.<code>controller</code> if present, or
               <code>null</code> otherwise.</p>
@@ -282,11 +287,6 @@
               [=transient activation=], return a promise <a>rejected</a> with a
               {{DOMException}} object whose {{DOMException/name}} attribute has
               the value {{InvalidStateError}}.</p>
-            </li>
-
-
-            <li>
-              <p>Let <var>options</var> be the method's first argument.</p>
             </li>
 
 

--- a/index.html
+++ b/index.html
@@ -291,65 +291,8 @@
 
 
             <li>
-              <p>Let <var>constraints</var> be
-              <code>[</code><var>options</var>.<code>audio</code>,
-              <var>options</var>.<code>video</code><code>]</code>.</p>
-            </li>
-
-
-            <li>
-              <p>If <code>constraints.video</code> is <code>false</code>,
-              return a promise [=reject|rejected=] with a newly
-              [=exception/created=] {{TypeError}}.</p>
-            </li>
-
-
-            <li>
-              <p>For each [= map/exist | existing =] member in
-              <var>constraints</var> whose value, <var>CS</var>, is a
-              dictionary, run the following steps:</p>
-
-
-              <ol>
-                <li>
-                  <p>If <var>CS</var> contains a member named
-                  <code>advanced</code>, return a promise [=reject|rejected=]
-                  with a newly [=exception/created=] {{TypeError}}.</p>
-                </li>
-
-
-                <li>
-                  <p>If <var>CS</var> contains a member whose name specifies a
-                  constrainable property applicable to [=display surface=]s,
-                  and whose value in turn is a dictionary containing a member
-                  named either <code>min</code> or <code>exact</code>, return a
-                  promise [=reject|rejected=] with a newly
-                  [=exception/created=] {{TypeError}}.</p>
-                </li>
-
-
-                <li>
-                  <p>If <var>CS</var> contains a member whose name specifies a
-                  constrainable property applicable to [=display surface=]s,
-                  and whose value in turn is a dictionary containing a member
-                  named <code>max</code>, and that member's value in turn is
-                  less than the constrainable property's [=floor value=], then
-                  let <var>failedConstraint</var> be the name of the member,
-                  let <var>message</var> be either <code>undefined</code> or an
-                  informative human-readable message, and return a promise
-                  [=reject|rejected=] with a new
-                  <code>OverconstrainedError</code> created by calling
-                  <code>OverconstrainedError(<var>failedConstraint</var>,
-                  <var>message</var>)</code>.</p>
-                </li>
-              </ol>
-            </li>
-
-
-            <li>
-              <p>Let <var>requestedMediaTypes</var> be the set of media types
-              in <var>constraints</var> with either a dictionary value or a
-              value of <code>true</code>.</p>
+              <p>Let <var>requestedMediaTypes</var> be the result of [=get media types=]
+              with <var>options</var>.</p>
             </li>
 
 
@@ -610,6 +553,75 @@
           consent</a>, for example if the capture of the video of a [= display
           surface/window =] is accompanied by capture of the audio of the
           entire system, including applications unrelated to that window.</p>
+
+
+          <p>To <dfn  class="abstract-op" id=
+          "get-media-types">get media types</dfn> with <var>options</var>,
+          run the following steps:</p>
+
+
+          <ol class=algorithm>
+            <li>
+              <p>Let <var>constraints</var> be
+              <code>[</code><var>options</var>.<code>audio</code>,
+              <var>options</var>.<code>video</code><code>]</code>.</p>
+            </li>
+
+
+            <li>
+              <p>If <code>constraints.video</code> is <code>false</code>,
+              return a promise [=reject|rejected=] with a newly
+              [=exception/created=] {{TypeError}}.</p>
+            </li>
+
+
+            <li>
+              <p>For each [= map/exist | existing =] member in
+              <var>constraints</var> whose value, <var>CS</var>, is a
+              dictionary, run the following steps:</p>
+
+
+              <ol>
+                <li>
+                  <p>If <var>CS</var> contains a member named
+                  <code>advanced</code>, return a promise [=reject|rejected=]
+                  with a newly [=exception/created=] {{TypeError}}.</p>
+                </li>
+
+
+                <li>
+                  <p>If <var>CS</var> contains a member whose name specifies a
+                  constrainable property applicable to [=display surface=]s,
+                  and whose value in turn is a dictionary containing a member
+                  named either <code>min</code> or <code>exact</code>, return a
+                  promise [=reject|rejected=] with a newly
+                  [=exception/created=] {{TypeError}}.</p>
+                </li>
+
+
+                <li>
+                  <p>If <var>CS</var> contains a member whose name specifies a
+                  constrainable property applicable to [=display surface=]s,
+                  and whose value in turn is a dictionary containing a member
+                  named <code>max</code>, and that member's value in turn is
+                  less than the constrainable property's [=floor value=], then
+                  let <var>failedConstraint</var> be the name of the member,
+                  let <var>message</var> be either <code>undefined</code> or an
+                  informative human-readable message, and return a promise
+                  [=reject|rejected=] with a new
+                  <code>OverconstrainedError</code> created by calling
+                  <code>OverconstrainedError(<var>failedConstraint</var>,
+                  <var>message</var>)</code>.</p>
+                </li>
+              </ol>
+            </li>
+
+
+            <li>
+              <p>Return the set of media types in <var>constraints</var>
+              with either a dictionary value or a value of <code>true</code>.</p>
+            </li>
+          </ol>
         </dd>
       </dl>
     </section>

--- a/index.html
+++ b/index.html
@@ -2586,5 +2586,135 @@ dictionary DisplayMediaStreamOptions {
       any active capture is advisable.</p>
     </section>
   </section>
+
+
+  <section>
+    <h2 id="automation">Automation</h2>
+
+
+    <p>The <dfn class="export">capture a browser tab</dfn> algorithm is used to capture a
+    browser tab for automation purposes, such as by [[WEBDRIVER-BIDI]].</p>
+
+
+    <p>Given a <var>browsingContext</var> and <var>options</var>, run the following
+    steps:</p>
+
+
+    <ol>
+      <li>
+        <p>Let <var>requestedMediaTypes</var> be the result of [=get media types=]
+        with <var>options</var>.</p>
+      </li>
+
+
+      <li>
+        <p>Let <var>p</var> be a new promise.</p>
+      </li>
+
+
+      <li>
+        <p>Run the following steps [=in parallel=]:</p>
+
+
+        <ol>
+          <li>
+            <p>For each media type <var>T</var> in
+            <var>requestedMediaTypes</var>,</p>
+
+
+            <ol>
+              <li>
+                <p>If no sources of type <var>T</var> are available,
+                [=queue a task=] to [=reject=] <var>p</var> with a new
+                {{DOMException}} object whose {{DOMException/name}}
+                attribute has the value {{NotFoundError}}, and abort
+                these steps.</p>
+              </li>
+            </ol>
+          </li>
+
+
+          <li>
+            <p>Let <var>videoSource</var> be the video source derived
+            from <var>browsingContext</var>.</p>
+          </li>
+
+
+          <li>
+            <p>If <var>options</var>.<code>audio</code> is
+            <code>true</code> or a dictionary, let <var>audioSource</var>
+            be the audio source from <var>browsingContext</var>.</p>
+          </li>
+
+
+          <li>
+            <p>If a hardware error such as an OS/program/webpage lock
+            prevents access, [=queue a task=] to [=reject=] <var>p</var>
+            with a new {{DOMException}} object whose {{DOMException/name}}
+            attribute has the value {{NotReadableError}}, and abort these
+            steps.</p>
+          </li>
+
+
+          <li>
+            <p>If device access fails for any reason other than those
+            listed above, [=queue a task=] to [=reject=] <var>p</var>
+            with a new {{DOMException}} object whose {{DOMException/name}}
+            attribute has the value {{AbortError}}, and abort these
+            steps.</p>
+          </li>
+
+
+          <li>
+            <p>Let <var>stream</var> be a {{MediaStream}} object.</p>
+          </li>
+
+
+          <li>
+            <p>For each source (<var>videoSource</var> and, if present,
+            <var>audioSource</var>), run the following steps:</p>
+
+            <ol>
+              <li>
+                <p>Let <var>track</var> be the result of [=create a
+                MediaStreamTrack|creating a MediaStreamTrack=] with the
+                source.</p>
+              </li>
+
+              <li>
+                <p>Add <var>track</var> to <var>stream</var>'s track
+                set.</p>
+              </li>
+            </ol>
+          </li>
+
+
+          <li>
+            <p>Run the [=ApplyConstraints algorithm=] on all tracks in
+            <var>stream</var> with the appropriate constraints. Should
+            this fail, let <var>failedConstraint</var> be the result of
+            the algorithm that failed, and let <var>message</var> be
+            either <code>undefined</code> or an informative
+            human-readable message, and then [=queue a task=] to
+            [=reject=] <var>p</var> with a new
+            <code>OverconstrainedError</code> created by calling
+            <code>OverconstrainedError(<var>failedConstraint</var>,
+            <var>message</var>)</code>, and abort these steps.</p>
+          </li>
+
+
+          <li>
+            <p>[=Queue a task=] to [=resolve=] <var>p</var> with
+            <var>stream</var>.</p>
+          </li>
+        </ol>
+      </li>
+
+
+      <li>
+        <p>Return <var>p</var>.</p>
+      </li>
+    </ol>
+  </section>
 </body>
 </html>


### PR DESCRIPTION
Hi here!
The Browser Testing and Tools Working Group would like to introduce the API in the WebDriver BiDi protocol to record a screen video during the test or automation scripts. The current suggestion is to base these commands on the `getDisplayMedia` API to produce the video stream (see https://github.com/w3c/webdriver-bidi/issues/636). 
Since we probably require bypassing a lot of pre-checks (user activation, permission, display surface selection), in this PR I've rather extracted the required logic in the separate algorithm, but please let me know if you have a better idea how to reuse the logic.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lutien/mediacapture-screen-share/pull/328.html" title="Last updated on Feb 6, 2026, 4:04 PM UTC (2764a27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/mediacapture-screen-share/328/81ad880...lutien:2764a27.html" title="Last updated on Feb 6, 2026, 4:04 PM UTC (2764a27)">Diff</a>